### PR TITLE
feat: REST API Endpoints (Phase 2.2) — Issue #10

### DIFF
--- a/backend/app/controllers/api/v1/artifacts_controller.rb
+++ b/backend/app/controllers/api/v1/artifacts_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ArtifactsController < ApplicationController
+      before_action :set_artifact, only: %i[show update]
+
+      # GET /api/v1/artifacts
+      def index
+        artifacts = paginate(Artifact.all.order(:name))
+        render json: artifacts
+      end
+
+      # GET /api/v1/artifacts/:id
+      def show
+        render json: artifact_detail(@artifact)
+      end
+
+      # POST /api/v1/artifacts
+      def create
+        artifact = Artifact.new(artifact_params)
+        if artifact.save
+          render json: artifact, status: :created
+        else
+          render json: { errors: artifact.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/artifacts/:id
+      def update
+        if @artifact.update(artifact_params)
+          render json: @artifact
+        else
+          render json: { errors: @artifact.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def set_artifact
+        @artifact = Artifact.find(params[:id])
+      end
+
+      def artifact_params
+        params.require(:artifact).permit(
+          :name, :artifact_type, :power, :corrupted, :character_id, stat_bonus: {}
+        )
+      end
+
+      def artifact_detail(artifact)
+        artifact.as_json.merge(
+          "character" => artifact.character&.as_json(only: %i[id name race level status])
+        )
+      end
+
+      def paginate(scope)
+        page = [params.fetch(:page, 1).to_i, 1].max
+        per  = params[:per_page].present? ? [[params[:per_page].to_i, 1].max, 100].min : 25
+        scope.limit(per).offset((page - 1) * per)
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/characters_controller.rb
+++ b/backend/app/controllers/api/v1/characters_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class CharactersController < ApplicationController
+      before_action :set_character, only: %i[show update destroy]
+
+      # GET /api/v1/characters
+      def index
+        characters = paginate(Character.all.order(:name))
+        render json: characters
+      end
+
+      # GET /api/v1/characters/:id
+      def show
+        render json: character_detail(@character)
+      end
+
+      # POST /api/v1/characters
+      def create
+        character = Character.new(character_params)
+        if character.save
+          render json: character, status: :created
+        else
+          render json: { errors: character.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/characters/:id
+      def update
+        if @character.update(character_params)
+          render json: @character
+        else
+          render json: { errors: @character.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/characters/:id
+      def destroy
+        @character.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_character
+        @character = Character.find(params[:id])
+      end
+
+      def character_params
+        params.require(:character).permit(
+          :name, :race, :realm, :title, :ring_bearer,
+          :level, :xp, :strength, :wisdom, :endurance, :status
+        )
+      end
+
+      def character_detail(character)
+        character.as_json.merge(
+          "quests" => character.quests.as_json(only: %i[id title status danger_level]),
+          "artifacts" => character.artifacts.as_json(only: %i[id name artifact_type power corrupted])
+        )
+      end
+
+      def paginate(scope)
+        page = [params.fetch(:page, 1).to_i, 1].max
+        per  = params[:per_page].present? ? [[params[:per_page].to_i, 1].max, 100].min : 25
+        scope.limit(per).offset((page - 1) * per)
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/events_controller.rb
+++ b/backend/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class EventsController < ApplicationController
+      # GET /api/v1/events
+      def index
+        events = QuestEvent.all.order(created_at: :desc)
+        events = events.where(event_type: params[:event_type]) if params[:event_type].present?
+        events = events.where(quest_id: params[:quest_id]) if params[:quest_id].present?
+        render json: paginate(events)
+      end
+
+      private
+
+      def paginate(scope)
+        page = [params.fetch(:page, 1).to_i, 1].max
+        per  = params[:per_page].present? ? [[params[:per_page].to_i, 1].max, 100].min : 25
+        scope.limit(per).offset((page - 1) * per)
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/leaderboard_controller.rb
+++ b/backend/app/controllers/api/v1/leaderboard_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class LeaderboardController < ApplicationController
+      # GET /api/v1/leaderboard
+      def index
+        per = params[:per_page].present? ? [[params[:per_page].to_i, 1].max, 100].min : 25
+        characters = Character.order(level: :desc, xp: :desc).limit(per)
+        render json: characters.as_json(only: %i[id name race level xp status])
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/palantir_controller.rb
+++ b/backend/app/controllers/api/v1/palantir_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class PalantirController < ApplicationController
+      # POST /api/v1/palantir/send
+      def deliver
+        message = params[:message].to_s.strip
+        if message.blank?
+          return render json: { error: "Message is required" }, status: :unprocessable_entity
+        end
+
+        PalantirJob.perform_later(message)
+        render json: { status: "queued", message: "Palantir message dispatched" }, status: :accepted
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/quests/events_controller.rb
+++ b/backend/app/controllers/api/v1/quests/events_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Quests
+      class EventsController < ApplicationController
+        # GET /api/v1/quests/:quest_id/events
+        def index
+          quest = Quest.find(params[:quest_id])
+          events = quest.quest_events.order(created_at: :desc)
+          render json: paginate(events)
+        end
+
+        private
+
+        def paginate(scope)
+          page = [params.fetch(:page, 1).to_i, 1].max
+          per  = params[:per_page].present? ? [[params[:per_page].to_i, 1].max, 100].min : 25
+          scope.limit(per).offset((page - 1) * per)
+        end
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/quests/members_controller.rb
+++ b/backend/app/controllers/api/v1/quests/members_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Quests
+      class MembersController < ApplicationController
+        before_action :set_quest
+
+        # POST /api/v1/quests/:quest_id/members
+        def create
+          character = Character.find(member_params[:character_id])
+
+          if on_active_quest?(character)
+            return render json: { error: "Character is already on an active quest" },
+                          status: :unprocessable_entity
+          end
+
+          membership = @quest.quest_memberships.build(
+            character: character,
+            role: member_params[:role]
+          )
+
+          if membership.save
+            render json: membership, status: :created
+          else
+            render json: { errors: membership.errors.full_messages }, status: :unprocessable_entity
+          end
+        end
+
+        # DELETE /api/v1/quests/:quest_id/members/:character_id
+        def destroy
+          membership = @quest.quest_memberships.find_by!(character_id: params[:character_id])
+          membership.destroy
+          head :no_content
+        end
+
+        private
+
+        def set_quest
+          @quest = Quest.find(params[:quest_id])
+        end
+
+        def member_params
+          if params[:member].present?
+            params.require(:member).permit(:character_id, :role)
+          else
+            params.permit(:character_id, :role)
+          end
+        end
+
+        def on_active_quest?(character)
+          QuestMembership.joins(:quest)
+                         .where(character_id: character.id)
+                         .where(quests: { status: "active" })
+                         .exists?
+        end
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/quests_controller.rb
+++ b/backend/app/controllers/api/v1/quests_controller.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class QuestsController < ApplicationController
+      before_action :set_quest, only: %i[show update destroy]
+
+      # GET /api/v1/quests
+      def index
+        quests = Quest.all.order(:title)
+        quests = quests.where(status: params[:status]) if params[:status].present?
+        render json: paginate(quests)
+      end
+
+      # GET /api/v1/quests/:id
+      def show
+        render json: quest_detail(@quest)
+      end
+
+      # POST /api/v1/quests
+      def create
+        quest = Quest.new(quest_params)
+        if quest.save
+          render json: quest, status: :created
+        else
+          render json: { errors: quest.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/quests/:id
+      def update
+        if @quest.update(quest_params)
+          render json: @quest
+        else
+          render json: { errors: @quest.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/quests/:id
+      def destroy
+        @quest.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_quest
+        @quest = Quest.find(params[:id])
+      end
+
+      def quest_params
+        params.require(:quest).permit(
+          :title, :description, :status, :danger_level,
+          :region, :progress, :success_chance, :quest_type,
+          :campaign_order, :attempts
+        )
+      end
+
+      def quest_detail(quest)
+        quest.as_json.merge(
+          "members" => quest.characters.as_json(only: %i[id name race level status]),
+          "success_chance" => quest.success_chance
+        )
+      end
+
+      def paginate(scope)
+        page = [params.fetch(:page, 1).to_i, 1].max
+        per  = params[:per_page].present? ? [[params[:per_page].to_i, 1].max, 100].min : 25
+        scope.limit(per).offset((page - 1) * per)
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/simulation_controller.rb
+++ b/backend/app/controllers/api/v1/simulation_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SimulationController < ApplicationController
+      # GET /api/v1/simulation/status
+      def status
+        render json: SimulationConfig.current
+      end
+
+      # POST /api/v1/simulation/start
+      def start
+        config = SimulationConfig.current
+        config.update!(running: true) unless config.running?
+        render json: config
+      end
+
+      # POST /api/v1/simulation/stop
+      def stop
+        config = SimulationConfig.current
+        config.update!(running: false) if config.running?
+        render json: config
+      end
+
+      # POST /api/v1/simulation/mode
+      def mode
+        new_mode = params[:mode].to_s
+        unless SimulationConfig.modes.key?(new_mode)
+          return render json: { error: "Invalid mode. Must be 'campaign' or 'random'" },
+                        status: :unprocessable_entity
+        end
+
+        config = SimulationConfig.current
+        config.update!(mode: new_mode)
+        render json: config
+      end
+
+      # POST /api/v1/simulation/reset
+      def reset
+        unless params[:confirm].to_s == "true"
+          return render json: { error: "Reset requires confirm: true" },
+                        status: :unprocessable_entity
+        end
+
+        config = SimulationConfig.current
+        config.update!(
+          running: false,
+          mode: "campaign",
+          campaign_position: 0
+        )
+        render json: config
+      end
+    end
+  end
+end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+  private
+
+  def not_found
+    render json: { error: "Not found" }, status: :not_found
+  end
 end

--- a/backend/app/jobs/application_job.rb
+++ b/backend/app/jobs/application_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/backend/app/jobs/palantir_job.rb
+++ b/backend/app/jobs/palantir_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PalantirJob < ApplicationJob
+  queue_as :default
+
+  def perform(message)
+    # Stub: creates a QuestEvent on the most recent active quest
+    quest = Quest.where(status: :active).order(created_at: :desc).first
+    return unless quest
+
+    QuestEvent.create!(
+      quest: quest,
+      event_type: :started,
+      message: "Palantir message received: #{message}"
+    )
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,5 +3,27 @@
 Rails.application.routes.draw do
   namespace :api do
     get "health", to: "health#show"
+
+    namespace :v1 do
+      resources :characters
+
+      resources :quests do
+        resources :members, only: %i[create destroy], param: :character_id,
+                  controller: "quests/members"
+        resources :events, only: %i[index], controller: "quests/events"
+      end
+
+      resources :artifacts, except: %i[destroy]
+
+      get  "simulation/status", to: "simulation#status"
+      post "simulation/start",  to: "simulation#start"
+      post "simulation/stop",   to: "simulation#stop"
+      post "simulation/mode",   to: "simulation#mode"
+      post "simulation/reset",  to: "simulation#reset"
+
+      resources :events, only: %i[index]
+      get "leaderboard", to: "leaderboard#index"
+      post "palantir/send", to: "palantir#deliver"
+    end
   end
 end

--- a/backend/spec/requests/api/v1/artifacts_spec.rb
+++ b/backend/spec/requests/api/v1/artifacts_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Artifacts", type: :request do
+  describe "GET /api/v1/artifacts" do
+    let!(:artifacts) { create_list(:artifact, 3) }
+
+    it "returns HTTP 200" do
+      get "/api/v1/artifacts"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns all artifacts" do
+      get "/api/v1/artifacts"
+      expect(response.parsed_body.length).to eq(3)
+    end
+  end
+
+  describe "GET /api/v1/artifacts/:id" do
+    let!(:character) { create(:character) }
+    let!(:artifact) { create(:artifact, character: character) }
+
+    it "returns HTTP 200" do
+      get "/api/v1/artifacts/#{artifact.id}"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns the artifact" do
+      get "/api/v1/artifacts/#{artifact.id}"
+      expect(response.parsed_body["id"]).to eq(artifact.id)
+    end
+
+    it "includes character holder details" do
+      get "/api/v1/artifacts/#{artifact.id}"
+      expect(response.parsed_body["character"]).to be_present
+      expect(response.parsed_body["character"]["id"]).to eq(character.id)
+    end
+
+    it "returns null character for unowned artifact" do
+      unowned = create(:artifact, character: nil)
+      get "/api/v1/artifacts/#{unowned.id}"
+      expect(response.parsed_body["character"]).to be_nil
+    end
+
+    it "returns 404 for unknown artifact" do
+      get "/api/v1/artifacts/0"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST /api/v1/artifacts" do
+    let(:valid_params) { { artifact: { name: "Sting", artifact_type: "sword" } } }
+
+    it "returns HTTP 201" do
+      post "/api/v1/artifacts", params: valid_params
+      expect(response).to have_http_status(:created)
+    end
+
+    it "creates an artifact" do
+      expect { post "/api/v1/artifacts", params: valid_params }
+        .to change(Artifact, :count).by(1)
+    end
+
+    it "returns 422 when name is missing" do
+      post "/api/v1/artifacts", params: { artifact: { artifact_type: "sword" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "PATCH /api/v1/artifacts/:id" do
+    let!(:artifact) { create(:artifact) }
+
+    it "returns HTTP 200" do
+      patch "/api/v1/artifacts/#{artifact.id}", params: { artifact: { name: "Updated Sting" } }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "updates the artifact" do
+      patch "/api/v1/artifacts/#{artifact.id}", params: { artifact: { name: "Updated Sting" } }
+      expect(artifact.reload.name).to eq("Updated Sting")
+    end
+
+    it "returns 422 with invalid params" do
+      patch "/api/v1/artifacts/#{artifact.id}", params: { artifact: { name: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/characters_spec.rb
+++ b/backend/spec/requests/api/v1/characters_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Characters", type: :request do
+  describe "GET /api/v1/characters" do
+    let!(:characters) { create_list(:character, 3) }
+
+    it "returns HTTP 200" do
+      get "/api/v1/characters"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns all characters" do
+      get "/api/v1/characters"
+      expect(response.parsed_body.length).to eq(3)
+    end
+
+    it "paginates results" do
+      get "/api/v1/characters", params: { per_page: 2, page: 1 }
+      expect(response.parsed_body.length).to eq(2)
+    end
+  end
+
+  describe "GET /api/v1/characters/:id" do
+    let!(:character) { create(:character) }
+    let!(:quest) { create(:quest) }
+    let!(:artifact) { create(:artifact, character: character) }
+
+    before { create(:quest_membership, character: character, quest: quest) }
+
+    it "returns HTTP 200" do
+      get "/api/v1/characters/#{character.id}"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns the character" do
+      get "/api/v1/characters/#{character.id}"
+      expect(response.parsed_body["id"]).to eq(character.id)
+    end
+
+    it "includes nested quests" do
+      get "/api/v1/characters/#{character.id}"
+      expect(response.parsed_body["quests"]).to be_an(Array)
+    end
+
+    it "includes nested artifacts" do
+      get "/api/v1/characters/#{character.id}"
+      expect(response.parsed_body["artifacts"]).to be_an(Array)
+    end
+
+    it "returns 404 for unknown character" do
+      get "/api/v1/characters/0"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST /api/v1/characters" do
+    let(:valid_params) do
+      {
+        character: {
+          name: "Gandalf",
+          race: "Wizard",
+          level: 20,
+          xp: 9999,
+          strength: 15,
+          wisdom: 20,
+          endurance: 12
+        }
+      }
+    end
+
+    it "returns HTTP 201 on success" do
+      post "/api/v1/characters", params: valid_params
+      expect(response).to have_http_status(:created)
+    end
+
+    it "creates the character" do
+      expect { post "/api/v1/characters", params: valid_params }
+        .to change(Character, :count).by(1)
+    end
+
+    it "returns 422 when name is missing" do
+      post "/api/v1/characters", params: { character: { race: "Elf", level: 1, strength: 5, wisdom: 5, endurance: 5 } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns error messages on failure" do
+      post "/api/v1/characters", params: { character: { race: "Elf" } }
+      expect(response.parsed_body["errors"]).to be_present
+    end
+  end
+
+  describe "PATCH /api/v1/characters/:id" do
+    let!(:character) { create(:character) }
+
+    it "returns HTTP 200 on success" do
+      patch "/api/v1/characters/#{character.id}", params: { character: { name: "Bilbo" } }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "updates the character" do
+      patch "/api/v1/characters/#{character.id}", params: { character: { name: "Bilbo" } }
+      expect(character.reload.name).to eq("Bilbo")
+    end
+
+    it "returns 422 with invalid params" do
+      patch "/api/v1/characters/#{character.id}", params: { character: { name: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns 404 for unknown character" do
+      patch "/api/v1/characters/0", params: { character: { name: "X" } }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE /api/v1/characters/:id" do
+    let!(:character) { create(:character) }
+
+    it "returns HTTP 204" do
+      delete "/api/v1/characters/#{character.id}"
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "destroys the character" do
+      expect { delete "/api/v1/characters/#{character.id}" }
+        .to change(Character, :count).by(-1)
+    end
+
+    it "returns 404 for unknown character" do
+      delete "/api/v1/characters/0"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/events_spec.rb
+++ b/backend/spec/requests/api/v1/events_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Events", type: :request do
+  let!(:quest) { create(:quest) }
+  let!(:events) { create_list(:quest_event, 3, quest: quest) }
+
+  describe "GET /api/v1/events" do
+    it "returns HTTP 200" do
+      get "/api/v1/events"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns all events" do
+      get "/api/v1/events"
+      expect(response.parsed_body.length).to eq(3)
+    end
+
+    it "filters by event_type" do
+      get "/api/v1/events", params: { event_type: "started" }
+      expect(response.parsed_body.all? { |e| e["event_type"] == "started" }).to be(true)
+    end
+
+    it "filters by quest_id" do
+      other_quest = create(:quest)
+      create(:quest_event, quest: other_quest, event_type: :progress)
+      get "/api/v1/events", params: { quest_id: quest.id }
+      expect(response.parsed_body.length).to eq(3)
+    end
+
+    it "paginates" do
+      get "/api/v1/events", params: { per_page: 2 }
+      expect(response.parsed_body.length).to eq(2)
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/leaderboard_spec.rb
+++ b/backend/spec/requests/api/v1/leaderboard_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Leaderboard", type: :request do
+  describe "GET /api/v1/leaderboard" do
+    let!(:high_level) { create(:character, level: 20, xp: 5000) }
+    let!(:mid_level)  { create(:character, level: 10, xp: 1000) }
+    let!(:low_level)  { create(:character, level: 1,  xp: 0) }
+
+    it "returns HTTP 200" do
+      get "/api/v1/leaderboard"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns characters ranked by level desc, xp desc" do
+      get "/api/v1/leaderboard"
+      ids = response.parsed_body.map { |c| c["id"] }
+      expect(ids).to eq([high_level.id, mid_level.id, low_level.id])
+    end
+
+    it "returns top 25 by default" do
+      create_list(:character, 30)
+      get "/api/v1/leaderboard"
+      expect(response.parsed_body.length).to eq(25)
+    end
+
+    it "includes relevant character fields" do
+      get "/api/v1/leaderboard"
+      char = response.parsed_body.first
+      expect(char.keys).to include("id", "name", "level", "xp", "status")
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/palantir_spec.rb
+++ b/backend/spec/requests/api/v1/palantir_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Palantir", type: :request do
+  describe "POST /api/v1/palantir/send" do
+    it "returns HTTP 202" do
+      post "/api/v1/palantir/send", params: { message: "All shall be lost!" }
+      expect(response).to have_http_status(:accepted)
+    end
+
+    it "returns a queued status" do
+      post "/api/v1/palantir/send", params: { message: "The Eye sees all" }
+      expect(response.parsed_body["status"]).to eq("queued")
+    end
+
+    it "returns 422 when message is blank" do
+      post "/api/v1/palantir/send", params: { message: "" }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns 422 when message is missing" do
+      post "/api/v1/palantir/send"
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/quests_spec.rb
+++ b/backend/spec/requests/api/v1/quests_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Quests", type: :request do
+  describe "GET /api/v1/quests" do
+    let!(:quests) { create_list(:quest, 3) }
+
+    it "returns HTTP 200" do
+      get "/api/v1/quests"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns all quests" do
+      get "/api/v1/quests"
+      expect(response.parsed_body.length).to eq(3)
+    end
+
+    it "filters by status" do
+      create(:quest, :active)
+      get "/api/v1/quests", params: { status: "active" }
+      expect(response.parsed_body.all? { |q| q["status"] == "active" }).to be(true)
+    end
+
+    it "paginates" do
+      get "/api/v1/quests", params: { per_page: 2 }
+      expect(response.parsed_body.length).to eq(2)
+    end
+  end
+
+  describe "GET /api/v1/quests/:id" do
+    let!(:quest) { create(:quest) }
+    let!(:character) { create(:character) }
+
+    before { create(:quest_membership, quest: quest, character: character) }
+
+    it "returns HTTP 200" do
+      get "/api/v1/quests/#{quest.id}"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns the quest" do
+      get "/api/v1/quests/#{quest.id}"
+      expect(response.parsed_body["id"]).to eq(quest.id)
+    end
+
+    it "includes members" do
+      get "/api/v1/quests/#{quest.id}"
+      expect(response.parsed_body["members"]).to be_an(Array)
+      expect(response.parsed_body["members"].first["id"]).to eq(character.id)
+    end
+
+    it "includes success_chance" do
+      get "/api/v1/quests/#{quest.id}"
+      expect(response.parsed_body).to have_key("success_chance")
+    end
+
+    it "returns 404 for unknown quest" do
+      get "/api/v1/quests/0"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST /api/v1/quests" do
+    let(:valid_params) { { quest: { title: "Destroy the Ring", danger_level: 10 } } }
+
+    it "returns HTTP 201" do
+      post "/api/v1/quests", params: valid_params
+      expect(response).to have_http_status(:created)
+    end
+
+    it "creates a quest" do
+      expect { post "/api/v1/quests", params: valid_params }
+        .to change(Quest, :count).by(1)
+    end
+
+    it "returns 422 when title is missing" do
+      post "/api/v1/quests", params: { quest: { danger_level: 5 } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "PATCH /api/v1/quests/:id" do
+    let!(:quest) { create(:quest) }
+
+    it "returns HTTP 200" do
+      patch "/api/v1/quests/#{quest.id}", params: { quest: { title: "New Title" } }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "updates the quest" do
+      patch "/api/v1/quests/#{quest.id}", params: { quest: { title: "New Title" } }
+      expect(quest.reload.title).to eq("New Title")
+    end
+
+    it "returns 422 with invalid params" do
+      patch "/api/v1/quests/#{quest.id}", params: { quest: { title: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns 404 for unknown quest" do
+      patch "/api/v1/quests/0", params: { quest: { title: "X" } }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE /api/v1/quests/:id" do
+    let!(:quest) { create(:quest) }
+
+    it "returns HTTP 204" do
+      delete "/api/v1/quests/#{quest.id}"
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "destroys the quest" do
+      expect { delete "/api/v1/quests/#{quest.id}" }
+        .to change(Quest, :count).by(-1)
+    end
+  end
+
+  describe "POST /api/v1/quests/:id/members" do
+    let!(:quest) { create(:quest, :active) }
+    let!(:character) { create(:character) }
+
+    it "returns HTTP 201" do
+      post "/api/v1/quests/#{quest.id}/members",
+           params: { character_id: character.id }
+      expect(response).to have_http_status(:created)
+    end
+
+    it "adds the character to the quest" do
+      expect {
+        post "/api/v1/quests/#{quest.id}/members",
+             params: { character_id: character.id }
+      }.to change(QuestMembership, :count).by(1)
+    end
+
+    it "returns 422 if character is already on an active quest" do
+      other_quest = create(:quest, :active)
+      create(:quest_membership, character: character, quest: other_quest)
+      post "/api/v1/quests/#{quest.id}/members",
+           params: { character_id: character.id }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "DELETE /api/v1/quests/:id/members/:character_id" do
+    let!(:quest) { create(:quest) }
+    let!(:character) { create(:character) }
+    let!(:membership) { create(:quest_membership, quest: quest, character: character) }
+
+    it "returns HTTP 204" do
+      delete "/api/v1/quests/#{quest.id}/members/#{character.id}"
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "removes the character from the quest" do
+      expect {
+        delete "/api/v1/quests/#{quest.id}/members/#{character.id}"
+      }.to change(QuestMembership, :count).by(-1)
+    end
+  end
+
+  describe "GET /api/v1/quests/:id/events" do
+    let!(:quest) { create(:quest) }
+    let!(:events) { create_list(:quest_event, 3, quest: quest) }
+
+    it "returns HTTP 200" do
+      get "/api/v1/quests/#{quest.id}/events"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns events for the quest" do
+      get "/api/v1/quests/#{quest.id}/events"
+      expect(response.parsed_body.length).to eq(3)
+    end
+
+    it "orders by created_at desc" do
+      get "/api/v1/quests/#{quest.id}/events"
+      times = response.parsed_body.map { |e| e["created_at"] }
+      expect(times).to eq(times.sort.reverse)
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/simulation_spec.rb
+++ b/backend/spec/requests/api/v1/simulation_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Simulation", type: :request do
+  before { SimulationConfig.destroy_all }
+
+  describe "GET /api/v1/simulation/status" do
+    it "returns HTTP 200" do
+      get "/api/v1/simulation/status"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns the simulation config" do
+      get "/api/v1/simulation/status"
+      expect(response.parsed_body).to include("running", "mode")
+    end
+  end
+
+  describe "POST /api/v1/simulation/start" do
+    it "returns HTTP 200" do
+      post "/api/v1/simulation/start"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "sets running to true" do
+      post "/api/v1/simulation/start"
+      expect(response.parsed_body["running"]).to be(true)
+    end
+
+    it "is idempotent when already running" do
+      config = SimulationConfig.current
+      config.update!(running: true)
+      post "/api/v1/simulation/start"
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["running"]).to be(true)
+    end
+  end
+
+  describe "POST /api/v1/simulation/stop" do
+    it "returns HTTP 200" do
+      post "/api/v1/simulation/stop"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "sets running to false" do
+      config = SimulationConfig.current
+      config.update!(running: true)
+      post "/api/v1/simulation/stop"
+      expect(response.parsed_body["running"]).to be(false)
+    end
+
+    it "is idempotent when already stopped" do
+      post "/api/v1/simulation/stop"
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["running"]).to be(false)
+    end
+  end
+
+  describe "POST /api/v1/simulation/mode" do
+    it "returns HTTP 200" do
+      post "/api/v1/simulation/mode", params: { mode: "random" }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "switches to random mode" do
+      post "/api/v1/simulation/mode", params: { mode: "random" }
+      expect(response.parsed_body["mode"]).to eq("random")
+    end
+
+    it "switches to campaign mode" do
+      SimulationConfig.current.update!(mode: "random")
+      post "/api/v1/simulation/mode", params: { mode: "campaign" }
+      expect(response.parsed_body["mode"]).to eq("campaign")
+    end
+
+    it "returns 422 for invalid mode" do
+      post "/api/v1/simulation/mode", params: { mode: "invalid" }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "POST /api/v1/simulation/reset" do
+    it "returns HTTP 200 with confirm: true" do
+      post "/api/v1/simulation/reset", params: { confirm: true }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "resets simulation state" do
+      config = SimulationConfig.current
+      config.update!(running: true, mode: "random", campaign_position: 5)
+      post "/api/v1/simulation/reset", params: { confirm: true }
+      expect(response.parsed_body["running"]).to be(false)
+      expect(response.parsed_body["mode"]).to eq("campaign")
+      expect(response.parsed_body["campaign_position"]).to eq(0)
+    end
+
+    it "returns 422 without confirm" do
+      post "/api/v1/simulation/reset"
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns 422 with confirm: false" do
+      post "/api/v1/simulation/reset", params: { confirm: false }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements the full `/api/v1/` REST surface for Characters, Quests, Artifacts, Simulation controls, Events, Leaderboard, and Palantir stub — 25+ endpoints, all covered by RSpec request specs (TDD).

Closes #10

## Changes

### Routes
- Full `namespace :api do namespace :v1 do` block with all resource routes
- Nested members + events routes under quests
- Flat simulation action routes (`/simulation/status`, `/simulation/start`, etc.)
- Leaderboard and Palantir stub routes

### Controllers (all thin — validation/persistence stays in models)
| Controller | Endpoints |
|---|---|
| `Api::V1::CharactersController` | GET index, GET show (w/ quests+artifacts), POST, PATCH, DELETE |
| `Api::V1::QuestsController` | GET index (filterable by `status`), GET show (w/ members), POST, PATCH, DELETE |
| `Api::V1::Quests::MembersController` | POST (add member, guards active-quest collision), DELETE |
| `Api::V1::Quests::EventsController` | GET index (ordered `created_at desc`, paginated) |
| `Api::V1::ArtifactsController` | GET index, GET show (w/ character holder), POST, PATCH |
| `Api::V1::SimulationController` | GET status, POST start/stop/mode/reset (idempotent start/stop; reset requires `confirm: true`) |
| `Api::V1::EventsController` | GET index (filterable by `event_type` + `quest_id`, paginated) |
| `Api::V1::LeaderboardController` | GET index (ranked `level desc, xp desc`, top 25) |
| `Api::V1::PalantirController` | POST deliver → enqueues `PalantirJob`, returns 202 |

### Other
- `ApplicationController` gains `rescue_from ActiveRecord::RecordNotFound` → clean JSON 404
- `PalantirJob` stub creates a `QuestEvent` on the most recent active quest when performed
- `ApplicationJob` base class added (was missing)
- Pagination via `page`/`per_page` query params (default 25, max 100) on all list endpoints

## Test Results
```
91 examples, 0 failures
```
All request specs pass, including happy-path and key error cases (422 validation, 404 not-found, 422 missing confirm, idempotent simulation ops, active-quest collision guard).

## Story
Implements all acceptance criteria from Issue #10. Depends on Issue #9 (Data Models & Migrations, merged via PR #15).

## Testing Instructions
```bash
docker compose run --rm backend bundle exec rspec spec/requests
# Expected: 91 examples, 0 failures
```

## Architectural Notes
- Pagination is intentionally inline (no Kaminari gem) to keep dependencies minimal; can be extracted to a `Paginatable` concern later if needed
- `PalantirJob` is a stub — real SQS integration deferred to Phase 4 (Issue out of scope)
- Simulation endpoints use `SimulationConfig.current` (find-or-create singleton) as specified

-- Devon (HiveLabs developer agent)