### PR TITLE
feat: OpenAPI Documentation — rswag + Scalar UI (Phase 2.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
       - name: Run RSpec
         run: bundle exec rspec
 
+      - name: Verify swagger spec is up to date
+        run: |
+          bundle exec rake rswag:specs:swaggerize
+          git diff --exit-code swagger/
+
   frontend:
     name: Frontend Checks
     runs-on: ubuntu-latest

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -10,12 +10,14 @@ gem "puma", ">= 5.0"
 gem "rack-cors"
 gem "bootsnap", require: false
 gem "tzinfo-data", platforms: %i[windows jruby]
+gem "rswag-api"
 
 group :development, :test do
   gem "debug", platforms: %i[mri windows]
   gem "rspec-rails", "~> 7.1"
   gem "factory_bot_rails"
   gem "faker"
+  gem "rswag-specs"
 end
 
 group :test do

--- a/backend/app/controllers/api/docs_controller.rb
+++ b/backend/app/controllers/api/docs_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module Api
+  class DocsController < ApplicationController
+    # GET /api/docs.json
+    # Serves the OpenAPI spec as JSON
+    def spec
+      spec_path = Rails.root.join("swagger", "v1", "swagger.yaml")
+      if spec_path.exist?
+        render json: YAML.safe_load(spec_path.read)
+      else
+        render json: { error: "OpenAPI spec not found" }, status: :not_found
+      end
+    end
+
+    # GET /api/docs
+    # Serves Scalar interactive API docs
+    def ui
+      render body: scalar_html, content_type: "text/html"
+    end
+
+    private
+
+    def scalar_html
+      <<~HTML
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <title>Mordor's Edge API Docs</title>
+          </head>
+          <body>
+            <script
+              id="api-reference"
+              data-url="/api/docs.json"
+              data-configuration='{"theme":"default"}'
+            ></script>
+            <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+          </body>
+        </html>
+      HTML
+    end
+  end
+end

--- a/backend/config/initializers/rswag_api.rb
+++ b/backend/config/initializers/rswag_api.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rswag::Api.configure do |c|
+  # Directory where swagger spec files are stored
+  c.openapi_root = Rails.root.join("swagger").to_s
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # OpenAPI spec (JSON) and Scalar interactive docs
+  get "/api/docs",      to: "api/docs#ui",   format: false
+  get "/api/docs.json", to: "api/docs#spec",  format: false
+
+  # rswag-api engine (serves swagger files from swagger/)
+  mount Rswag::Api::Engine => "/api-docs"
+
   namespace :api do
     get "health", to: "health#show"
 

--- a/backend/spec/integration/artifacts_spec.rb
+++ b/backend/spec/integration/artifacts_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Artifacts", type: :request do
+  path "/api/v1/artifacts" do
+    get "List all artifacts" do
+      tags "Artifacts"
+      operationId "listArtifacts"
+      produces "application/json"
+      description "Returns a paginated list of all artifacts, ordered by name."
+
+      parameter name: :page, in: :query, schema: { type: :integer, example: 1 },
+                required: false, description: "Page number (default: 1)"
+      parameter name: :per_page, in: :query, schema: { type: :integer, example: 25 },
+                required: false, description: "Results per page (max: 100, default: 25)"
+
+      response "200", "artifacts retrieved" do
+        schema type: :array, items: { "$ref" => "#/components/schemas/Artifact" }
+        before { create_list(:artifact, 2) }
+        run_test!
+      end
+    end
+
+    post "Create an artifact" do
+      tags "Artifacts"
+      operationId "createArtifact"
+      consumes "application/json"
+      produces "application/json"
+      description "Creates a new artifact. Artifacts may optionally be assigned to a character."
+
+      parameter name: :body, in: :body, required: true, schema: {
+        type: :object,
+        required: [:artifact],
+        properties: {
+          artifact: { "$ref" => "#/components/schemas/ArtifactInput" }
+        }
+      }
+
+      response "201", "artifact created" do
+        schema "$ref" => "#/components/schemas/Artifact"
+        let(:body) do
+          {
+            artifact: {
+              name: "The One Ring",
+              artifact_type: "ring",
+              power: 100,
+              corrupted: true,
+              stat_bonus: { "wisdom" => -10, "charisma" => 50 }
+            }
+          }
+        end
+        run_test!
+      end
+
+      response "422", "validation failed" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+        let(:body) { { artifact: { name: "", artifact_type: "" } } }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/artifacts/{id}" do
+    parameter name: :id, in: :path, schema: { type: :integer }, required: true,
+              description: "Artifact ID", example: 1
+
+    get "Get an artifact" do
+      tags "Artifacts"
+      operationId "getArtifact"
+      produces "application/json"
+      description "Returns a single artifact with its owning character (if assigned)."
+
+      response "200", "artifact found" do
+        schema "$ref" => "#/components/schemas/ArtifactDetail"
+        let(:id) { create(:artifact).id }
+        run_test!
+      end
+
+      response "404", "artifact not found" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) { 0 }
+        run_test!
+      end
+    end
+
+    patch "Update an artifact" do
+      tags "Artifacts"
+      operationId "updateArtifact"
+      consumes "application/json"
+      produces "application/json"
+      description "Updates an existing artifact. Artifacts cannot be destroyed once created."
+
+      parameter name: :body, in: :body, required: true, schema: {
+        type: :object,
+        required: [:artifact],
+        properties: {
+          artifact: { "$ref" => "#/components/schemas/ArtifactInput" }
+        }
+      }
+
+      response "200", "artifact updated" do
+        schema "$ref" => "#/components/schemas/Artifact"
+        let(:id) { create(:artifact).id }
+        let(:body) do
+          {
+            artifact: {
+              name: "Narya the Ring of Fire",
+              artifact_type: "ring",
+              power: 85,
+              corrupted: false
+            }
+          }
+        end
+        run_test!
+      end
+
+      response "404", "artifact not found" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) { 0 }
+        let(:body) { { artifact: { name: "Nenya", artifact_type: "ring", power: 80 } } }
+        run_test!
+      end
+
+      response "422", "validation failed" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+        let(:id) { create(:artifact).id }
+        let(:body) { { artifact: { name: "", artifact_type: "" } } }
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/integration/characters_spec.rb
+++ b/backend/spec/integration/characters_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Characters", type: :request do
+  path "/api/v1/characters" do
+    get "List all characters" do
+      tags "Characters"
+      operationId "listCharacters"
+      produces "application/json"
+      description "Returns a paginated list of all characters, ordered by name."
+
+      parameter name: :page, in: :query, schema: { type: :integer, example: 1 },
+                required: false, description: "Page number (default: 1)"
+      parameter name: :per_page, in: :query, schema: { type: :integer, example: 25 },
+                required: false, description: "Results per page (max: 100, default: 25)"
+
+      response "200", "characters retrieved" do
+        schema type: :array, items: { "$ref" => "#/components/schemas/Character" }
+        before { create_list(:character, 2) }
+        run_test!
+      end
+    end
+
+    post "Create a character" do
+      tags "Characters"
+      operationId "createCharacter"
+      consumes "application/json"
+      produces "application/json"
+      description "Creates a new character in the simulation."
+
+      parameter name: :body, in: :body, required: true, schema: {
+        type: :object,
+        required: [:character],
+        properties: {
+          character: { "$ref" => "#/components/schemas/CharacterInput" }
+        }
+      }
+
+      response "201", "character created" do
+        schema "$ref" => "#/components/schemas/Character"
+        let(:body) do
+          {
+            character: {
+              name: "Aragorn",
+              race: "Human",
+              realm: "Gondor",
+              title: "Ranger of the North",
+              level: 20,
+              xp: 5000,
+              strength: 18,
+              wisdom: 14,
+              endurance: 16
+            }
+          }
+        end
+        run_test!
+      end
+
+      response "422", "validation failed" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+        let(:body) { { character: { name: "", race: "", level: 0, strength: 0, wisdom: 0, endurance: 0 } } }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/characters/{id}" do
+    parameter name: :id, in: :path, schema: { type: :integer }, required: true,
+              description: "Character ID", example: 1
+
+    get "Get a character" do
+      tags "Characters"
+      operationId "getCharacter"
+      produces "application/json"
+      description "Returns a single character with their quests and artifacts."
+
+      response "200", "character found" do
+        schema "$ref" => "#/components/schemas/CharacterDetail"
+        let(:id) { create(:character).id }
+        run_test!
+      end
+
+      response "404", "character not found" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) { 0 }
+        run_test!
+      end
+    end
+
+    patch "Update a character" do
+      tags "Characters"
+      operationId "updateCharacter"
+      consumes "application/json"
+      produces "application/json"
+      description "Updates an existing character's attributes."
+
+      parameter name: :body, in: :body, required: true, schema: {
+        type: :object,
+        required: [:character],
+        properties: {
+          character: { "$ref" => "#/components/schemas/CharacterInput" }
+        }
+      }
+
+      response "200", "character updated" do
+        schema "$ref" => "#/components/schemas/Character"
+        let(:id) { create(:character).id }
+        let(:body) { { character: { name: "Boromir", realm: "Gondor", title: "Captain of Gondor" } } }
+        run_test!
+      end
+
+      response "404", "character not found" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) { 0 }
+        let(:body) { { character: { name: "Boromir" } } }
+        run_test!
+      end
+
+      response "422", "validation failed" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+        let(:id) { create(:character).id }
+        let(:body) { { character: { name: "" } } }
+        run_test!
+      end
+    end
+
+    delete "Delete a character" do
+      tags "Characters"
+      operationId "deleteCharacter"
+      description "Permanently removes a character from the simulation."
+
+      response "204", "character deleted" do
+        let(:id) { create(:character).id }
+        run_test!
+      end
+
+      response "404", "character not found" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) { 0 }
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/integration/events_spec.rb
+++ b/backend/spec/integration/events_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Events", type: :request do
+  path "/api/v1/events" do
+    get "List all events" do
+      tags "Events"
+      operationId "listEvents"
+      produces "application/json"
+      description "Returns a paginated list of quest events across all quests. Supports filtering by event_type and quest_id."
+
+      parameter name: :event_type, in: :query,
+                schema: { type: :string, enum: %w[started progress completed failed restarted] },
+                required: false, description: "Filter by event type"
+      parameter name: :quest_id, in: :query, schema: { type: :integer },
+                required: false, description: "Filter events by quest"
+      parameter name: :page, in: :query, schema: { type: :integer, example: 1 },
+                required: false, description: "Page number (default: 1)"
+      parameter name: :per_page, in: :query, schema: { type: :integer, example: 25 },
+                required: false, description: "Results per page (max: 100, default: 25)"
+
+      response "200", "events retrieved" do
+        schema type: :array, items: { "$ref" => "#/components/schemas/QuestEvent" }
+        before do
+          quest = create(:quest)
+          create_list(:quest_event, 2, quest: quest)
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/integration/health_spec.rb
+++ b/backend/spec/integration/health_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Health", type: :request do
+  path "/api/health" do
+    get "Check API health" do
+      tags "Health"
+      operationId "getHealth"
+      produces "application/json"
+      description "Returns the API status, version, and environment. Useful for liveness probes."
+
+      response "200", "API is healthy" do
+        schema "$ref" => "#/components/schemas/HealthStatus"
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/integration/leaderboard_spec.rb
+++ b/backend/spec/integration/leaderboard_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Leaderboard", type: :request do
+  path "/api/v1/leaderboard" do
+    get "Get the leaderboard" do
+      tags "Leaderboard"
+      operationId "getLeaderboard"
+      produces "application/json"
+      description "Returns the top characters ranked by level (descending) then XP (descending)."
+
+      parameter name: :per_page, in: :query, schema: { type: :integer, example: 25 },
+                required: false, description: "Number of entries to return (max: 100, default: 25)"
+
+      response "200", "leaderboard retrieved" do
+        schema type: :array, items: { "$ref" => "#/components/schemas/LeaderboardEntry" }
+        before { create_list(:character, 3) }
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/integration/palantir_spec.rb
+++ b/backend/spec/integration/palantir_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Palantir", type: :request do
+  path "/api/v1/palantir/send" do
+    post "Send a Palantir message" do
+      tags "Palantir"
+      operationId "sendPalantirMessage"
+      consumes "application/json"
+      produces "application/json"
+      description "Dispatches an asynchronous message via the Palantir (the seeing-stone). " \
+                  "The message is queued for background processing."
+
+      parameter name: :body, in: :body, required: true, schema: {
+        type: :object,
+        required: [:message],
+        properties: {
+          message: {
+            type: :string,
+            description: "The message to dispatch through the Palantir",
+            example: "The Eye of Sauron has turned toward Gondor."
+          }
+        }
+      }
+
+      response "202", "message queued" do
+        schema "$ref" => "#/components/schemas/QueuedResponse"
+        let(:body) { { message: "Fly, you fools!" } }
+        run_test!
+      end
+
+      response "422", "message is blank" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:body) { { message: "" } }
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/integration/quests_spec.rb
+++ b/backend/spec/integration/quests_spec.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Quests", type: :request do
+  path "/api/v1/quests" do
+    get "List all quests" do
+      tags "Quests"
+      operationId "listQuests"
+      produces "application/json"
+      description "Returns a paginated list of quests. Optionally filter by status."
+
+      parameter name: :status, in: :query,
+                schema: { type: :string, enum: %w[pending active completed failed] },
+                required: false, description: "Filter quests by status"
+      parameter name: :page, in: :query, schema: { type: :integer, example: 1 },
+                required: false, description: "Page number (default: 1)"
+      parameter name: :per_page, in: :query, schema: { type: :integer, example: 25 },
+                required: false, description: "Results per page (max: 100, default: 25)"
+
+      response "200", "quests retrieved" do
+        schema type: :array, items: { "$ref" => "#/components/schemas/Quest" }
+        before { create_list(:quest, 2) }
+        run_test!
+      end
+    end
+
+    post "Create a quest" do
+      tags "Quests"
+      operationId "createQuest"
+      consumes "application/json"
+      produces "application/json"
+      description "Creates a new quest in the simulation."
+
+      parameter name: :body, in: :body, required: true, schema: {
+        type: :object,
+        required: [:quest],
+        properties: {
+          quest: { "$ref" => "#/components/schemas/QuestInput" }
+        }
+      }
+
+      response "201", "quest created" do
+        schema "$ref" => "#/components/schemas/Quest"
+        let(:body) do
+          {
+            quest: {
+              title: "Destroy the One Ring",
+              description: "Cast the One Ring into the fires of Mount Doom.",
+              danger_level: 10,
+              region: "Mordor",
+              quest_type: "campaign",
+              campaign_order: 1
+            }
+          }
+        end
+        run_test!
+      end
+
+      response "422", "validation failed" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+        let(:body) { { quest: { title: "", danger_level: 0 } } }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/quests/{id}" do
+    parameter name: :id, in: :path, schema: { type: :integer }, required: true,
+              description: "Quest ID", example: 1
+
+    get "Get a quest" do
+      tags "Quests"
+      operationId "getQuest"
+      produces "application/json"
+      description "Returns a single quest with its member list and success chance."
+
+      response "200", "quest found" do
+        schema "$ref" => "#/components/schemas/QuestDetail"
+        let(:id) { create(:quest).id }
+        run_test!
+      end
+
+      response "404", "quest not found" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) { 0 }
+        run_test!
+      end
+    end
+
+    patch "Update a quest" do
+      tags "Quests"
+      operationId "updateQuest"
+      consumes "application/json"
+      produces "application/json"
+      description "Updates an existing quest's attributes."
+
+      parameter name: :body, in: :body, required: true, schema: {
+        type: :object,
+        required: [:quest],
+        properties: {
+          quest: { "$ref" => "#/components/schemas/QuestInput" }
+        }
+      }
+
+      response "200", "quest updated" do
+        schema "$ref" => "#/components/schemas/Quest"
+        let(:id) { create(:quest).id }
+        let(:body) { { quest: { title: "The Battle of Pelennor Fields", region: "Gondor", danger_level: 9 } } }
+        run_test!
+      end
+
+      response "404", "quest not found" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) { 0 }
+        let(:body) { { quest: { title: "Phantom Quest", danger_level: 1 } } }
+        run_test!
+      end
+
+      response "422", "validation failed" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+        let(:id) { create(:quest).id }
+        let(:body) { { quest: { title: "" } } }
+        run_test!
+      end
+    end
+
+    delete "Delete a quest" do
+      tags "Quests"
+      operationId "deleteQuest"
+      description "Permanently removes a quest from the simulation."
+
+      response "204", "quest deleted" do
+        let(:id) { create(:quest).id }
+        run_test!
+      end
+
+      response "404", "quest not found" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) { 0 }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/quests/{quest_id}/members" do
+    parameter name: :quest_id, in: :path, schema: { type: :integer }, required: true,
+              description: "Quest ID", example: 1
+
+    post "Add a member to a quest" do
+      tags "Quest Members"
+      operationId "addQuestMember"
+      consumes "application/json"
+      produces "application/json"
+      description "Adds a character to a quest. A character may only be on one active quest at a time."
+
+      parameter name: :body, in: :body, required: true, schema: {
+        type: :object,
+        required: [:character_id],
+        properties: {
+          character_id: { type: :integer, description: "ID of the character to add", example: 1 },
+          role: { type: :string, description: "Optional role for the character on this quest", example: "guide" }
+        }
+      }
+
+      response "201", "member added" do
+        let(:quest_id) { create(:quest, :active).id }
+        let(:body) { { character_id: create(:character).id } }
+        run_test!
+      end
+
+      response "422", "character already on an active quest" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:other_quest) { create(:quest, :active) }
+        let(:the_character) { create(:character) }
+        let(:quest_id) do
+          create(:quest_membership, quest: other_quest, character: the_character)
+          create(:quest, :active).id
+        end
+        let(:body) { { character_id: the_character.id } }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/quests/{quest_id}/members/{character_id}" do
+    parameter name: :quest_id, in: :path, schema: { type: :integer }, required: true,
+              description: "Quest ID", example: 1
+    parameter name: :character_id, in: :path, schema: { type: :integer }, required: true,
+              description: "Character ID to remove", example: 1
+
+    delete "Remove a member from a quest" do
+      tags "Quest Members"
+      operationId "removeQuestMember"
+      description "Removes a character from a quest."
+
+      response "204", "member removed" do
+        let(:the_quest) { create(:quest) }
+        let(:the_character) { create(:character) }
+        let(:quest_id) do
+          create(:quest_membership, quest: the_quest, character: the_character)
+          the_quest.id
+        end
+        let(:character_id) { the_character.id }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/quests/{quest_id}/events" do
+    parameter name: :quest_id, in: :path, schema: { type: :integer }, required: true,
+              description: "Quest ID", example: 1
+    parameter name: :page, in: :query, schema: { type: :integer, example: 1 },
+              required: false, description: "Page number (default: 1)"
+    parameter name: :per_page, in: :query, schema: { type: :integer, example: 25 },
+              required: false, description: "Results per page (max: 100, default: 25)"
+
+    get "List events for a quest" do
+      tags "Quest Events"
+      operationId "listQuestEvents"
+      produces "application/json"
+      description "Returns quest events in reverse chronological order."
+
+      response "200", "events retrieved" do
+        schema type: :array, items: { "$ref" => "#/components/schemas/QuestEvent" }
+        let(:the_quest) { create(:quest) }
+        let(:quest_id) do
+          create_list(:quest_event, 2, quest: the_quest)
+          the_quest.id
+        end
+        run_test!
+      end
+
+      response "404", "quest not found" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:quest_id) { 0 }
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/integration/simulation_spec.rb
+++ b/backend/spec/integration/simulation_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Simulation", type: :request do
+  path "/api/v1/simulation/status" do
+    get "Get simulation status" do
+      tags "Simulation"
+      operationId "getSimulationStatus"
+      produces "application/json"
+      description "Returns the current simulation configuration including mode, running state, and position."
+
+      response "200", "simulation status retrieved" do
+        schema "$ref" => "#/components/schemas/SimulationConfig"
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/simulation/start" do
+    post "Start the simulation" do
+      tags "Simulation"
+      operationId "startSimulation"
+      produces "application/json"
+      description "Starts the simulation engine. Has no effect if already running."
+
+      response "200", "simulation started (or already running)" do
+        schema "$ref" => "#/components/schemas/SimulationConfig"
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/simulation/stop" do
+    post "Stop the simulation" do
+      tags "Simulation"
+      operationId "stopSimulation"
+      produces "application/json"
+      description "Stops the simulation engine. Has no effect if already stopped."
+
+      response "200", "simulation stopped (or already stopped)" do
+        schema "$ref" => "#/components/schemas/SimulationConfig"
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/simulation/mode" do
+    post "Set simulation mode" do
+      tags "Simulation"
+      operationId "setSimulationMode"
+      consumes "application/json"
+      produces "application/json"
+      description "Switches the simulation between campaign and random mode."
+
+      parameter name: :body, in: :body, required: true, schema: {
+        type: :object,
+        required: [:mode],
+        properties: {
+          mode: {
+            type: :string,
+            enum: %w[campaign random],
+            description: "The desired simulation mode",
+            example: "campaign"
+          }
+        }
+      }
+
+      response "200", "mode updated" do
+        schema "$ref" => "#/components/schemas/SimulationConfig"
+        let(:body) { { mode: "random" } }
+        run_test!
+      end
+
+      response "422", "invalid mode" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:body) { { mode: "turbo" } }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/simulation/reset" do
+    post "Reset the simulation" do
+      tags "Simulation"
+      operationId "resetSimulation"
+      consumes "application/json"
+      produces "application/json"
+      description "Resets the simulation to its initial state. Requires explicit confirmation."
+
+      parameter name: :body, in: :body, required: true, schema: {
+        type: :object,
+        required: [:confirm],
+        properties: {
+          confirm: {
+            type: :boolean,
+            description: "Must be true to confirm the reset",
+            example: true
+          }
+        }
+      }
+
+      response "200", "simulation reset" do
+        schema "$ref" => "#/components/schemas/SimulationConfig"
+        let(:body) { { confirm: true } }
+        run_test!
+      end
+
+      response "422", "confirmation missing or false" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:body) { { confirm: false } }
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.configure do |config|
+  config.openapi_root = Rails.root.join("swagger").to_s
+
+  config.openapi_specs = {
+    "v1/swagger.yaml" => {
+      openapi: "3.0.3",
+      info: {
+        title: "Mordor's Edge API",
+        version: "v1",
+        description: "API for the Mordor's Edge fantasy RPG simulation — manage characters, " \
+                     "quests, artifacts, and the simulation engine."
+      },
+      servers: [
+        { url: "/", description: "Default server" }
+      ],
+      components: {
+        schemas: {
+          Character: {
+            type: :object,
+            description: "A character in the simulation",
+            properties: {
+              id: { type: :integer, example: 1 },
+              name: { type: :string, example: "Aragorn" },
+              race: { type: :string, example: "Human" },
+              realm: { type: :string, nullable: true, example: "Gondor" },
+              title: { type: :string, nullable: true, example: "Ranger of the North" },
+              ring_bearer: { type: :boolean, example: false },
+              level: { type: :integer, example: 20 },
+              xp: { type: :integer, example: 5000 },
+              strength: { type: :integer, example: 18 },
+              wisdom: { type: :integer, example: 14 },
+              endurance: { type: :integer, example: 16 },
+              status: { type: :string, enum: %w[idle on_quest fallen], example: "idle" },
+              created_at: { type: :string, format: "date-time" },
+              updated_at: { type: :string, format: "date-time" }
+            },
+            required: %w[id name race level xp strength wisdom endurance status]
+          },
+
+          CharacterDetail: {
+            allOf: [
+              { "$ref" => "#/components/schemas/Character" },
+              {
+                type: :object,
+                description: "Character with nested quests and artifacts",
+                properties: {
+                  quests: {
+                    type: :array,
+                    items: { "$ref" => "#/components/schemas/QuestSummary" }
+                  },
+                  artifacts: {
+                    type: :array,
+                    items: { "$ref" => "#/components/schemas/ArtifactSummary" }
+                  }
+                }
+              }
+            ]
+          },
+
+          CharacterSummary: {
+            type: :object,
+            description: "Abbreviated character info used in nested responses",
+            properties: {
+              id: { type: :integer, example: 1 },
+              name: { type: :string, example: "Legolas" },
+              race: { type: :string, example: "Elf" },
+              level: { type: :integer, example: 15 },
+              status: { type: :string, enum: %w[idle on_quest fallen], example: "on_quest" }
+            },
+            required: %w[id name race level status]
+          },
+
+          CharacterInput: {
+            type: :object,
+            description: "Payload for creating or updating a character",
+            properties: {
+              name: { type: :string, example: "Aragorn" },
+              race: { type: :string, example: "Human" },
+              realm: { type: :string, example: "Gondor" },
+              title: { type: :string, example: "Ranger of the North" },
+              ring_bearer: { type: :boolean, example: false },
+              level: { type: :integer, example: 20 },
+              xp: { type: :integer, example: 5000 },
+              strength: { type: :integer, example: 18 },
+              wisdom: { type: :integer, example: 14 },
+              endurance: { type: :integer, example: 16 },
+              status: { type: :string, enum: %w[idle on_quest fallen] }
+            },
+            required: %w[name race strength wisdom endurance]
+          },
+
+          Quest: {
+            type: :object,
+            description: "A quest in the simulation",
+            properties: {
+              id: { type: :integer, example: 1 },
+              title: { type: :string, example: "Destroy the One Ring" },
+              description: {
+                type: :string, nullable: true,
+                example: "Journey to Mount Doom and cast the Ring into the fires of Orodruin."
+              },
+              status: { type: :string, enum: %w[pending active completed failed], example: "active" },
+              danger_level: { type: :integer, minimum: 1, maximum: 10, example: 10 },
+              region: { type: :string, nullable: true, example: "Mordor" },
+              # decimal columns — Rails serializes as strings to preserve precision
+              progress: { type: :string, example: "0.0000", description: "Decimal (0–1 scale)" },
+              success_chance: {
+                type: :string, nullable: true, example: "0.4550",
+                description: "Decimal success probability (0–1 scale), null if uncalculated"
+              },
+              quest_type: { type: :string, enum: %w[campaign random], example: "campaign" },
+              campaign_order: { type: :integer, nullable: true, example: 1 },
+              attempts: { type: :integer, example: 0 },
+              created_at: { type: :string, format: "date-time" },
+              updated_at: { type: :string, format: "date-time" }
+            },
+            required: %w[id title status danger_level]
+          },
+
+          QuestDetail: {
+            allOf: [
+              { "$ref" => "#/components/schemas/Quest" },
+              {
+                type: :object,
+                description: "Quest with nested member list",
+                properties: {
+                  members: {
+                    type: :array,
+                    items: { "$ref" => "#/components/schemas/CharacterSummary" }
+                  }
+                }
+              }
+            ]
+          },
+
+          QuestSummary: {
+            type: :object,
+            description: "Abbreviated quest info used in nested responses",
+            properties: {
+              id: { type: :integer, example: 1 },
+              title: { type: :string, example: "Destroy the One Ring" },
+              status: { type: :string, enum: %w[pending active completed failed], example: "active" },
+              danger_level: { type: :integer, example: 10 }
+            },
+            required: %w[id title status danger_level]
+          },
+
+          QuestInput: {
+            type: :object,
+            description: "Payload for creating or updating a quest",
+            properties: {
+              title: { type: :string, example: "The Battle of Helm's Deep" },
+              description: { type: :string, example: "Defend the fortress against Saruman's army." },
+              status: { type: :string, enum: %w[pending active completed failed] },
+              danger_level: { type: :integer, minimum: 1, maximum: 10, example: 8 },
+              region: { type: :string, example: "Rohan" },
+              progress: { type: :string, example: "0.0" },
+              quest_type: { type: :string, enum: %w[campaign random] },
+              campaign_order: { type: :integer, example: 2 },
+              attempts: { type: :integer, example: 0 }
+            },
+            required: %w[title danger_level]
+          },
+
+          Artifact: {
+            type: :object,
+            description: "A magical artifact in the simulation",
+            properties: {
+              id: { type: :integer, example: 1 },
+              name: { type: :string, example: "The One Ring" },
+              artifact_type: { type: :string, example: "ring" },
+              # power is stored as text in the database
+              power: { type: :string, nullable: true, example: "100", description: "Artifact power level (text column)" },
+              corrupted: { type: :boolean, example: true },
+              character_id: { type: :integer, nullable: true, example: 1 },
+              # stat_bonus is a JSONB column, null: false, defaults to {}
+              stat_bonus: {
+                type: :object, additionalProperties: true,
+                example: { "wisdom" => 5 },
+                description: "JSONB bonus stats map; empty object {} when none set"
+              },
+              created_at: { type: :string, format: "date-time" },
+              updated_at: { type: :string, format: "date-time" }
+            },
+            required: %w[id name artifact_type]
+          },
+
+          ArtifactDetail: {
+            allOf: [
+              { "$ref" => "#/components/schemas/Artifact" },
+              {
+                type: :object,
+                description: "Artifact with owning character details",
+                properties: {
+                  character: {
+                    nullable: true,
+                    allOf: [{ "$ref" => "#/components/schemas/CharacterSummary" }]
+                  }
+                }
+              }
+            ]
+          },
+
+          ArtifactSummary: {
+            type: :object,
+            description: "Abbreviated artifact info used in nested responses",
+            properties: {
+              id: { type: :integer, example: 1 },
+              name: { type: :string, example: "Sting" },
+              artifact_type: { type: :string, example: "sword" },
+              power: { type: :string, nullable: true, example: "75" },
+              corrupted: { type: :boolean, example: false }
+            },
+            required: %w[id name artifact_type]
+          },
+
+          ArtifactInput: {
+            type: :object,
+            description: "Payload for creating or updating an artifact",
+            properties: {
+              name: { type: :string, example: "Mithril Coat" },
+              artifact_type: { type: :string, example: "armour" },
+              power: { type: :string, example: "90" },
+              corrupted: { type: :boolean, example: false },
+              character_id: { type: :integer, nullable: true, example: 1 },
+              stat_bonus: {
+                type: :object,
+                additionalProperties: true,
+                example: { "endurance" => 20 }
+              }
+            },
+            required: %w[name artifact_type]
+          },
+
+          QuestEvent: {
+            type: :object,
+            description: "An event recorded on a quest (append-only; no updated_at)",
+            properties: {
+              id: { type: :integer, example: 1 },
+              quest_id: { type: :integer, example: 1 },
+              event_type: {
+                type: :string,
+                enum: %w[started progress completed failed restarted],
+                example: "progress"
+              },
+              message: {
+                type: :string,
+                nullable: true,
+                example: "The fellowship has crossed the Misty Mountains."
+              },
+              # data is JSONB null: false, defaults to {}
+              data: {
+                type: :object, additionalProperties: true,
+                description: "JSONB payload; empty object {} when not set"
+              },
+              created_at: { type: :string, format: "date-time" }
+            },
+            required: %w[id quest_id event_type]
+          },
+
+          SimulationConfig: {
+            type: :object,
+            description: "Global simulation configuration (singleton)",
+            properties: {
+              id: { type: :integer, example: 1 },
+              mode: { type: :string, enum: %w[campaign random], example: "campaign" },
+              running: { type: :boolean, example: false },
+              tick_interval_seconds: { type: :integer, example: 60 },
+              # decimal columns — Rails serializes as strings
+              progress_min: {
+                type: :string, example: "0.0100",
+                description: "Minimum tick progress increment (decimal string)"
+              },
+              progress_max: {
+                type: :string, example: "0.1000",
+                description: "Maximum tick progress increment (decimal string)"
+              },
+              campaign_position: { type: :integer, example: 0 },
+              created_at: { type: :string, format: "date-time" },
+              updated_at: { type: :string, format: "date-time" }
+            },
+            required: %w[id mode running]
+          },
+
+          LeaderboardEntry: {
+            type: :object,
+            description: "Character summary for leaderboard ranking",
+            properties: {
+              id: { type: :integer, example: 1 },
+              name: { type: :string, example: "Gandalf the White" },
+              race: { type: :string, example: "Wizard" },
+              level: { type: :integer, example: 20 },
+              xp: { type: :integer, example: 99_999 },
+              status: { type: :string, enum: %w[idle on_quest fallen], example: "idle" }
+            },
+            required: %w[id name level xp status]
+          },
+
+          QueuedResponse: {
+            type: :object,
+            description: "Acknowledgement that an async message was dispatched",
+            properties: {
+              status: { type: :string, example: "queued" },
+              message: { type: :string, example: "Palantir message dispatched" }
+            },
+            required: %w[status message]
+          },
+
+          HealthStatus: {
+            type: :object,
+            description: "API health check response",
+            properties: {
+              status: { type: :string, example: "ok" },
+              version: { type: :string, example: "0.1.0" },
+              environment: { type: :string, example: "production" }
+            },
+            required: %w[status version environment]
+          },
+
+          ErrorResponse: {
+            type: :object,
+            description: "Single-error response",
+            properties: {
+              error: { type: :string, example: "Not found" }
+            },
+            required: %w[error]
+          },
+
+          ValidationErrors: {
+            type: :object,
+            description: "Validation failure response with multiple messages",
+            properties: {
+              errors: {
+                type: :array,
+                items: { type: :string },
+                example: ["Name can't be blank", "Level must be greater than 0"]
+              }
+            },
+            required: %w[errors]
+          }
+        }
+      }
+    }
+  }
+
+  config.openapi_format = :yaml
+end

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -1,0 +1,1334 @@
+---
+openapi: 3.0.3
+info:
+  title: Mordor's Edge API
+  version: v1
+  description: API for the Mordor's Edge fantasy RPG simulation — manage characters,
+    quests, artifacts, and the simulation engine.
+servers:
+- url: "/"
+  description: Default server
+components:
+  schemas:
+    Character:
+      type: object
+      description: A character in the simulation
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Aragorn
+        race:
+          type: string
+          example: Human
+        realm:
+          type: string
+          nullable: true
+          example: Gondor
+        title:
+          type: string
+          nullable: true
+          example: Ranger of the North
+        ring_bearer:
+          type: boolean
+          example: false
+        level:
+          type: integer
+          example: 20
+        xp:
+          type: integer
+          example: 5000
+        strength:
+          type: integer
+          example: 18
+        wisdom:
+          type: integer
+          example: 14
+        endurance:
+          type: integer
+          example: 16
+        status:
+          type: string
+          enum:
+          - idle
+          - on_quest
+          - fallen
+          example: idle
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+      - id
+      - name
+      - race
+      - level
+      - xp
+      - strength
+      - wisdom
+      - endurance
+      - status
+    CharacterDetail:
+      allOf:
+      - "$ref": "#/components/schemas/Character"
+      - type: object
+        description: Character with nested quests and artifacts
+        properties:
+          quests:
+            type: array
+            items:
+              "$ref": "#/components/schemas/QuestSummary"
+          artifacts:
+            type: array
+            items:
+              "$ref": "#/components/schemas/ArtifactSummary"
+    CharacterSummary:
+      type: object
+      description: Abbreviated character info used in nested responses
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Legolas
+        race:
+          type: string
+          example: Elf
+        level:
+          type: integer
+          example: 15
+        status:
+          type: string
+          enum:
+          - idle
+          - on_quest
+          - fallen
+          example: on_quest
+      required:
+      - id
+      - name
+      - race
+      - level
+      - status
+    CharacterInput:
+      type: object
+      description: Payload for creating or updating a character
+      properties:
+        name:
+          type: string
+          example: Aragorn
+        race:
+          type: string
+          example: Human
+        realm:
+          type: string
+          example: Gondor
+        title:
+          type: string
+          example: Ranger of the North
+        ring_bearer:
+          type: boolean
+          example: false
+        level:
+          type: integer
+          example: 20
+        xp:
+          type: integer
+          example: 5000
+        strength:
+          type: integer
+          example: 18
+        wisdom:
+          type: integer
+          example: 14
+        endurance:
+          type: integer
+          example: 16
+        status:
+          type: string
+          enum:
+          - idle
+          - on_quest
+          - fallen
+      required:
+      - name
+      - race
+      - strength
+      - wisdom
+      - endurance
+    Quest:
+      type: object
+      description: A quest in the simulation
+      properties:
+        id:
+          type: integer
+          example: 1
+        title:
+          type: string
+          example: Destroy the One Ring
+        description:
+          type: string
+          nullable: true
+          example: Journey to Mount Doom and cast the Ring into the fires of Orodruin.
+        status:
+          type: string
+          enum:
+          - pending
+          - active
+          - completed
+          - failed
+          example: active
+        danger_level:
+          type: integer
+          minimum: 1
+          maximum: 10
+          example: 10
+        region:
+          type: string
+          nullable: true
+          example: Mordor
+        progress:
+          type: string
+          example: '0.0000'
+          description: Decimal (0–1 scale)
+        success_chance:
+          type: string
+          nullable: true
+          example: '0.4550'
+          description: Decimal success probability (0–1 scale), null if uncalculated
+        quest_type:
+          type: string
+          enum:
+          - campaign
+          - random
+          example: campaign
+        campaign_order:
+          type: integer
+          nullable: true
+          example: 1
+        attempts:
+          type: integer
+          example: 0
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+      - id
+      - title
+      - status
+      - danger_level
+    QuestDetail:
+      allOf:
+      - "$ref": "#/components/schemas/Quest"
+      - type: object
+        description: Quest with nested member list
+        properties:
+          members:
+            type: array
+            items:
+              "$ref": "#/components/schemas/CharacterSummary"
+    QuestSummary:
+      type: object
+      description: Abbreviated quest info used in nested responses
+      properties:
+        id:
+          type: integer
+          example: 1
+        title:
+          type: string
+          example: Destroy the One Ring
+        status:
+          type: string
+          enum:
+          - pending
+          - active
+          - completed
+          - failed
+          example: active
+        danger_level:
+          type: integer
+          example: 10
+      required:
+      - id
+      - title
+      - status
+      - danger_level
+    QuestInput:
+      type: object
+      description: Payload for creating or updating a quest
+      properties:
+        title:
+          type: string
+          example: The Battle of Helm's Deep
+        description:
+          type: string
+          example: Defend the fortress against Saruman's army.
+        status:
+          type: string
+          enum:
+          - pending
+          - active
+          - completed
+          - failed
+        danger_level:
+          type: integer
+          minimum: 1
+          maximum: 10
+          example: 8
+        region:
+          type: string
+          example: Rohan
+        progress:
+          type: string
+          example: '0.0'
+        quest_type:
+          type: string
+          enum:
+          - campaign
+          - random
+        campaign_order:
+          type: integer
+          example: 2
+        attempts:
+          type: integer
+          example: 0
+      required:
+      - title
+      - danger_level
+    Artifact:
+      type: object
+      description: A magical artifact in the simulation
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: The One Ring
+        artifact_type:
+          type: string
+          example: ring
+        power:
+          type: string
+          nullable: true
+          example: '100'
+          description: Artifact power level (text column)
+        corrupted:
+          type: boolean
+          example: true
+        character_id:
+          type: integer
+          nullable: true
+          example: 1
+        stat_bonus:
+          type: object
+          additionalProperties: true
+          example:
+            wisdom: 5
+          description: JSONB bonus stats map; empty object {} when none set
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+      - id
+      - name
+      - artifact_type
+    ArtifactDetail:
+      allOf:
+      - "$ref": "#/components/schemas/Artifact"
+      - type: object
+        description: Artifact with owning character details
+        properties:
+          character:
+            nullable: true
+            allOf:
+            - "$ref": "#/components/schemas/CharacterSummary"
+    ArtifactSummary:
+      type: object
+      description: Abbreviated artifact info used in nested responses
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Sting
+        artifact_type:
+          type: string
+          example: sword
+        power:
+          type: string
+          nullable: true
+          example: '75'
+        corrupted:
+          type: boolean
+          example: false
+      required:
+      - id
+      - name
+      - artifact_type
+    ArtifactInput:
+      type: object
+      description: Payload for creating or updating an artifact
+      properties:
+        name:
+          type: string
+          example: Mithril Coat
+        artifact_type:
+          type: string
+          example: armour
+        power:
+          type: string
+          example: '90'
+        corrupted:
+          type: boolean
+          example: false
+        character_id:
+          type: integer
+          nullable: true
+          example: 1
+        stat_bonus:
+          type: object
+          additionalProperties: true
+          example:
+            endurance: 20
+      required:
+      - name
+      - artifact_type
+    QuestEvent:
+      type: object
+      description: An event recorded on a quest (append-only; no updated_at)
+      properties:
+        id:
+          type: integer
+          example: 1
+        quest_id:
+          type: integer
+          example: 1
+        event_type:
+          type: string
+          enum:
+          - started
+          - progress
+          - completed
+          - failed
+          - restarted
+          example: progress
+        message:
+          type: string
+          nullable: true
+          example: The fellowship has crossed the Misty Mountains.
+        data:
+          type: object
+          additionalProperties: true
+          description: JSONB payload; empty object {} when not set
+        created_at:
+          type: string
+          format: date-time
+      required:
+      - id
+      - quest_id
+      - event_type
+    SimulationConfig:
+      type: object
+      description: Global simulation configuration (singleton)
+      properties:
+        id:
+          type: integer
+          example: 1
+        mode:
+          type: string
+          enum:
+          - campaign
+          - random
+          example: campaign
+        running:
+          type: boolean
+          example: false
+        tick_interval_seconds:
+          type: integer
+          example: 60
+        progress_min:
+          type: string
+          example: '0.0100'
+          description: Minimum tick progress increment (decimal string)
+        progress_max:
+          type: string
+          example: '0.1000'
+          description: Maximum tick progress increment (decimal string)
+        campaign_position:
+          type: integer
+          example: 0
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+      - id
+      - mode
+      - running
+    LeaderboardEntry:
+      type: object
+      description: Character summary for leaderboard ranking
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Gandalf the White
+        race:
+          type: string
+          example: Wizard
+        level:
+          type: integer
+          example: 20
+        xp:
+          type: integer
+          example: 99999
+        status:
+          type: string
+          enum:
+          - idle
+          - on_quest
+          - fallen
+          example: idle
+      required:
+      - id
+      - name
+      - level
+      - xp
+      - status
+    QueuedResponse:
+      type: object
+      description: Acknowledgement that an async message was dispatched
+      properties:
+        status:
+          type: string
+          example: queued
+        message:
+          type: string
+          example: Palantir message dispatched
+      required:
+      - status
+      - message
+    HealthStatus:
+      type: object
+      description: API health check response
+      properties:
+        status:
+          type: string
+          example: ok
+        version:
+          type: string
+          example: 0.1.0
+        environment:
+          type: string
+          example: production
+      required:
+      - status
+      - version
+      - environment
+    ErrorResponse:
+      type: object
+      description: Single-error response
+      properties:
+        error:
+          type: string
+          example: Not found
+      required:
+      - error
+    ValidationErrors:
+      type: object
+      description: Validation failure response with multiple messages
+      properties:
+        errors:
+          type: array
+          items:
+            type: string
+          example:
+          - Name can't be blank
+          - Level must be greater than 0
+      required:
+      - errors
+paths:
+  "/api/v1/artifacts":
+    get:
+      summary: List all artifacts
+      tags:
+      - Artifacts
+      operationId: listArtifacts
+      description: Returns a paginated list of all artifacts, ordered by name.
+      parameters:
+      - name: page
+        in: query
+        schema:
+          type: integer
+          example: 1
+        required: false
+        description: 'Page number (default: 1)'
+      - name: per_page
+        in: query
+        schema:
+          type: integer
+          example: 25
+        required: false
+        description: 'Results per page (max: 100, default: 25)'
+      responses:
+        '200':
+          description: artifacts retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Artifact"
+    post:
+      summary: Create an artifact
+      tags:
+      - Artifacts
+      operationId: createArtifact
+      description: Creates a new artifact. Artifacts may optionally be assigned to
+        a character.
+      parameters: []
+      responses:
+        '201':
+          description: artifact created
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Artifact"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - artifact
+              properties:
+                artifact:
+                  "$ref": "#/components/schemas/ArtifactInput"
+        required: true
+  "/api/v1/artifacts/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: integer
+      required: true
+      description: Artifact ID
+      example: 1
+    get:
+      summary: Get an artifact
+      tags:
+      - Artifacts
+      operationId: getArtifact
+      description: Returns a single artifact with its owning character (if assigned).
+      responses:
+        '200':
+          description: artifact found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ArtifactDetail"
+        '404':
+          description: artifact not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update an artifact
+      tags:
+      - Artifacts
+      operationId: updateArtifact
+      description: Updates an existing artifact. Artifacts cannot be destroyed once
+        created.
+      parameters: []
+      responses:
+        '200':
+          description: artifact updated
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Artifact"
+        '404':
+          description: artifact not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - artifact
+              properties:
+                artifact:
+                  "$ref": "#/components/schemas/ArtifactInput"
+        required: true
+  "/api/v1/characters":
+    get:
+      summary: List all characters
+      tags:
+      - Characters
+      operationId: listCharacters
+      description: Returns a paginated list of all characters, ordered by name.
+      parameters:
+      - name: page
+        in: query
+        schema:
+          type: integer
+          example: 1
+        required: false
+        description: 'Page number (default: 1)'
+      - name: per_page
+        in: query
+        schema:
+          type: integer
+          example: 25
+        required: false
+        description: 'Results per page (max: 100, default: 25)'
+      responses:
+        '200':
+          description: characters retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Character"
+    post:
+      summary: Create a character
+      tags:
+      - Characters
+      operationId: createCharacter
+      description: Creates a new character in the simulation.
+      parameters: []
+      responses:
+        '201':
+          description: character created
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Character"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - character
+              properties:
+                character:
+                  "$ref": "#/components/schemas/CharacterInput"
+        required: true
+  "/api/v1/characters/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: integer
+      required: true
+      description: Character ID
+      example: 1
+    get:
+      summary: Get a character
+      tags:
+      - Characters
+      operationId: getCharacter
+      description: Returns a single character with their quests and artifacts.
+      responses:
+        '200':
+          description: character found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CharacterDetail"
+        '404':
+          description: character not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update a character
+      tags:
+      - Characters
+      operationId: updateCharacter
+      description: Updates an existing character's attributes.
+      parameters: []
+      responses:
+        '200':
+          description: character updated
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Character"
+        '404':
+          description: character not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - character
+              properties:
+                character:
+                  "$ref": "#/components/schemas/CharacterInput"
+        required: true
+    delete:
+      summary: Delete a character
+      tags:
+      - Characters
+      operationId: deleteCharacter
+      description: Permanently removes a character from the simulation.
+      responses:
+        '204':
+          description: character deleted
+        '404':
+          description: character not found
+  "/api/v1/events":
+    get:
+      summary: List all events
+      tags:
+      - Events
+      operationId: listEvents
+      description: Returns a paginated list of quest events across all quests. Supports
+        filtering by event_type and quest_id.
+      parameters:
+      - name: event_type
+        in: query
+        schema:
+          type: string
+          enum:
+          - started
+          - progress
+          - completed
+          - failed
+          - restarted
+        required: false
+        description: Filter by event type
+      - name: quest_id
+        in: query
+        schema:
+          type: integer
+        required: false
+        description: Filter events by quest
+      - name: page
+        in: query
+        schema:
+          type: integer
+          example: 1
+        required: false
+        description: 'Page number (default: 1)'
+      - name: per_page
+        in: query
+        schema:
+          type: integer
+          example: 25
+        required: false
+        description: 'Results per page (max: 100, default: 25)'
+      responses:
+        '200':
+          description: events retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/QuestEvent"
+  "/api/health":
+    get:
+      summary: Check API health
+      tags:
+      - Health
+      operationId: getHealth
+      description: Returns the API status, version, and environment. Useful for liveness
+        probes.
+      responses:
+        '200':
+          description: API is healthy
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/HealthStatus"
+  "/api/v1/leaderboard":
+    get:
+      summary: Get the leaderboard
+      tags:
+      - Leaderboard
+      operationId: getLeaderboard
+      description: Returns the top characters ranked by level (descending) then XP
+        (descending).
+      parameters:
+      - name: per_page
+        in: query
+        schema:
+          type: integer
+          example: 25
+        required: false
+        description: 'Number of entries to return (max: 100, default: 25)'
+      responses:
+        '200':
+          description: leaderboard retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/LeaderboardEntry"
+  "/api/v1/palantir/send":
+    post:
+      summary: Send a Palantir message
+      tags:
+      - Palantir
+      operationId: sendPalantirMessage
+      description: Dispatches an asynchronous message via the Palantir (the seeing-stone).
+        The message is queued for background processing.
+      parameters: []
+      responses:
+        '202':
+          description: message queued
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/QueuedResponse"
+        '422':
+          description: message is blank
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - message
+              properties:
+                message:
+                  type: string
+                  description: The message to dispatch through the Palantir
+                  example: The Eye of Sauron has turned toward Gondor.
+        required: true
+  "/api/v1/quests":
+    get:
+      summary: List all quests
+      tags:
+      - Quests
+      operationId: listQuests
+      description: Returns a paginated list of quests. Optionally filter by status.
+      parameters:
+      - name: status
+        in: query
+        schema:
+          type: string
+          enum:
+          - pending
+          - active
+          - completed
+          - failed
+        required: false
+        description: Filter quests by status
+      - name: page
+        in: query
+        schema:
+          type: integer
+          example: 1
+        required: false
+        description: 'Page number (default: 1)'
+      - name: per_page
+        in: query
+        schema:
+          type: integer
+          example: 25
+        required: false
+        description: 'Results per page (max: 100, default: 25)'
+      responses:
+        '200':
+          description: quests retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Quest"
+    post:
+      summary: Create a quest
+      tags:
+      - Quests
+      operationId: createQuest
+      description: Creates a new quest in the simulation.
+      parameters: []
+      responses:
+        '201':
+          description: quest created
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Quest"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - quest
+              properties:
+                quest:
+                  "$ref": "#/components/schemas/QuestInput"
+        required: true
+  "/api/v1/quests/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: integer
+      required: true
+      description: Quest ID
+      example: 1
+    get:
+      summary: Get a quest
+      tags:
+      - Quests
+      operationId: getQuest
+      description: Returns a single quest with its member list and success chance.
+      responses:
+        '200':
+          description: quest found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/QuestDetail"
+        '404':
+          description: quest not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update a quest
+      tags:
+      - Quests
+      operationId: updateQuest
+      description: Updates an existing quest's attributes.
+      parameters: []
+      responses:
+        '200':
+          description: quest updated
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Quest"
+        '404':
+          description: quest not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - quest
+              properties:
+                quest:
+                  "$ref": "#/components/schemas/QuestInput"
+        required: true
+    delete:
+      summary: Delete a quest
+      tags:
+      - Quests
+      operationId: deleteQuest
+      description: Permanently removes a quest from the simulation.
+      responses:
+        '204':
+          description: quest deleted
+        '404':
+          description: quest not found
+  "/api/v1/quests/{quest_id}/members":
+    parameters:
+    - name: quest_id
+      in: path
+      schema:
+        type: integer
+      required: true
+      description: Quest ID
+      example: 1
+    post:
+      summary: Add a member to a quest
+      tags:
+      - Quest Members
+      operationId: addQuestMember
+      description: Adds a character to a quest. A character may only be on one active
+        quest at a time.
+      parameters: []
+      responses:
+        '201':
+          description: member added
+        '422':
+          description: character already on an active quest
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - character_id
+              properties:
+                character_id:
+                  type: integer
+                  description: ID of the character to add
+                  example: 1
+                role:
+                  type: string
+                  description: Optional role for the character on this quest
+                  example: guide
+        required: true
+  "/api/v1/quests/{quest_id}/members/{character_id}":
+    parameters:
+    - name: quest_id
+      in: path
+      schema:
+        type: integer
+      required: true
+      description: Quest ID
+      example: 1
+    - name: character_id
+      in: path
+      schema:
+        type: integer
+      required: true
+      description: Character ID to remove
+      example: 1
+    delete:
+      summary: Remove a member from a quest
+      tags:
+      - Quest Members
+      operationId: removeQuestMember
+      description: Removes a character from a quest.
+      responses:
+        '204':
+          description: member removed
+  "/api/v1/quests/{quest_id}/events":
+    parameters:
+    - name: quest_id
+      in: path
+      schema:
+        type: integer
+      required: true
+      description: Quest ID
+      example: 1
+    - name: page
+      in: query
+      schema:
+        type: integer
+        example: 1
+      required: false
+      description: 'Page number (default: 1)'
+    - name: per_page
+      in: query
+      schema:
+        type: integer
+        example: 25
+      required: false
+      description: 'Results per page (max: 100, default: 25)'
+    get:
+      summary: List events for a quest
+      tags:
+      - Quest Events
+      operationId: listQuestEvents
+      description: Returns quest events in reverse chronological order.
+      responses:
+        '200':
+          description: events retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/QuestEvent"
+        '404':
+          description: quest not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/simulation/status":
+    get:
+      summary: Get simulation status
+      tags:
+      - Simulation
+      operationId: getSimulationStatus
+      description: Returns the current simulation configuration including mode, running
+        state, and position.
+      responses:
+        '200':
+          description: simulation status retrieved
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SimulationConfig"
+  "/api/v1/simulation/start":
+    post:
+      summary: Start the simulation
+      tags:
+      - Simulation
+      operationId: startSimulation
+      description: Starts the simulation engine. Has no effect if already running.
+      responses:
+        '200':
+          description: simulation started (or already running)
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SimulationConfig"
+  "/api/v1/simulation/stop":
+    post:
+      summary: Stop the simulation
+      tags:
+      - Simulation
+      operationId: stopSimulation
+      description: Stops the simulation engine. Has no effect if already stopped.
+      responses:
+        '200':
+          description: simulation stopped (or already stopped)
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SimulationConfig"
+  "/api/v1/simulation/mode":
+    post:
+      summary: Set simulation mode
+      tags:
+      - Simulation
+      operationId: setSimulationMode
+      description: Switches the simulation between campaign and random mode.
+      parameters: []
+      responses:
+        '200':
+          description: mode updated
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SimulationConfig"
+        '422':
+          description: invalid mode
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - mode
+              properties:
+                mode:
+                  type: string
+                  enum:
+                  - campaign
+                  - random
+                  description: The desired simulation mode
+                  example: campaign
+        required: true
+  "/api/v1/simulation/reset":
+    post:
+      summary: Reset the simulation
+      tags:
+      - Simulation
+      operationId: resetSimulation
+      description: Resets the simulation to its initial state. Requires explicit confirmation.
+      parameters: []
+      responses:
+        '200':
+          description: simulation reset
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SimulationConfig"
+        '422':
+          description: confirmation missing or false
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - confirm
+              properties:
+                confirm:
+                  type: boolean
+                  description: Must be true to confirm the reset
+                  example: true
+        required: true


### PR DESCRIPTION
## Summary

Adds live OpenAPI 3.0.3 documentation to the Mordor's Edge API, driven by rswag request specs and served via Scalar UI at `GET /api/docs`.

- **rswag-api + rswag-specs** gems added; spec generated from RSpec integration tests
- **45 new rswag integration specs** covering every `/api/v1/` endpoint
- **`swagger/v1/swagger.yaml`** committed and kept in sync by a CI diff-check step
- **`GET /api/docs`** → Scalar interactive UI (CDN-loaded)
- **`GET /api/docs.json`** → OpenAPI spec served as JSON
- **`GET /api-docs/v1/swagger.yaml`** → raw spec via `Rswag::Api::Engine`

## Changes

| File | Change |
|---|---|
| `backend/Gemfile` | Add `rswag-api` (prod) and `rswag-specs` (dev/test) |
| `backend/config/routes.rb` | Mount `Rswag::Api::Engine`; add `/api/docs` and `/api/docs.json` |
| `backend/config/initializers/rswag_api.rb` | Configure rswag openapi root |
| `backend/spec/swagger_helper.rb` | OpenAPI 3.0.3 metadata + 14 component schemas |
| `backend/spec/integration/*_spec.rb` | rswag specs for all 8 resource groups |
| `backend/swagger/v1/swagger.yaml` | Generated spec (1334 lines, stable/idempotent) |
| `backend/app/controllers/api/docs_controller.rb` | `#ui` (Scalar HTML) + `#spec` (JSON) |
| `.github/workflows/ci.yml` | Add `rswag:specs:swaggerize` + `git diff swagger/` gate |

## Schema notes

Two column type quirks documented in the schemas:
- `artifact.power` is a `text` column → serialized as a string
- `quest.progress`, `quest.success_chance`, `simulation_config.progress_min/max` are `decimal` columns → Rails serializes as strings to preserve precision; schemas correctly typed as `string` with `description` noting the decimal semantics

## Testing

```
bundle exec rspec                         # 221 examples, 0 failures
bundle exec rspec spec/integration        # 45 examples, 0 failures
bundle exec rake rswag:specs:swaggerize   # generates swagger.yaml (idempotent)
```

## Story

Closes #11

-- Devon (HiveLabs developer agent)