### PR TITLE
feat: GraphQL Mutations (Phase 3.4)

### DIFF
--- a/backend/app/graphql/mutations/artifacts/assign_artifact.rb
+++ b/backend/app/graphql/mutations/artifacts/assign_artifact.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Artifacts
+    class AssignArtifact < BaseMutation
+      description "Assign or unassign an artifact to/from a character"
+
+      argument :id, ID, required: true
+      argument :character_id, ID, required: false
+
+      field :artifact, Types::ArtifactType, null: true
+      field :errors, [String], null: false
+
+      def resolve(id:, character_id: nil)
+        artifact = Artifact.find(id)
+        if artifact.update(character_id: character_id)
+          { artifact: artifact, errors: [] }
+        else
+          { artifact: nil, errors: artifact.errors.full_messages }
+        end
+      rescue ActiveRecord::RecordNotFound
+        { artifact: nil, errors: ["Artifact not found: #{id}"] }
+      end
+    end
+  end
+end

--- a/backend/app/graphql/mutations/artifacts/create_artifact.rb
+++ b/backend/app/graphql/mutations/artifacts/create_artifact.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Artifacts
+    class CreateArtifact < BaseMutation
+      description "Create a new artifact"
+
+      argument :input, Types::Input::ArtifactInputType, required: true
+
+      field :artifact, Types::ArtifactType, null: true
+      field :errors, [String], null: false
+
+      def resolve(input:)
+        artifact = Artifact.new(input.to_h.compact)
+        if artifact.save
+          { artifact: artifact, errors: [] }
+        else
+          { artifact: nil, errors: artifact.errors.full_messages }
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        { artifact: nil, errors: e.record.errors.full_messages }
+      end
+    end
+  end
+end

--- a/backend/app/graphql/mutations/artifacts/update_artifact.rb
+++ b/backend/app/graphql/mutations/artifacts/update_artifact.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Artifacts
+    class UpdateArtifact < BaseMutation
+      description "Update an existing artifact"
+
+      argument :id, ID, required: true
+      argument :input, Types::Input::ArtifactInputType, required: true
+
+      field :artifact, Types::ArtifactType, null: true
+      field :errors, [String], null: false
+
+      def resolve(id:, input:)
+        artifact = Artifact.find(id)
+        if artifact.update(input.to_h.compact)
+          { artifact: artifact, errors: [] }
+        else
+          { artifact: nil, errors: artifact.errors.full_messages }
+        end
+      rescue ActiveRecord::RecordNotFound
+        { artifact: nil, errors: ["Artifact not found: #{id}"] }
+      rescue ActiveRecord::RecordInvalid => e
+        { artifact: nil, errors: e.record.errors.full_messages }
+      end
+    end
+  end
+end

--- a/backend/app/graphql/mutations/base_mutation.rb
+++ b/backend/app/graphql/mutations/base_mutation.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Mutations
+  class BaseMutation < GraphQL::Schema::Mutation
+    argument_class Types::BaseArgument
+    field_class Types::BaseField
+    object_class Types::BaseObject
+  end
+end

--- a/backend/app/graphql/mutations/characters/create_character.rb
+++ b/backend/app/graphql/mutations/characters/create_character.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Characters
+    class CreateCharacter < BaseMutation
+      description "Create a new character"
+
+      argument :input, Types::Input::CharacterInputType, required: true
+
+      field :character, Types::CharacterType, null: true
+      field :errors, [String], null: false
+
+      def resolve(input:)
+        character = Character.new(input.to_h.compact)
+        if character.save
+          { character: character, errors: [] }
+        else
+          { character: nil, errors: character.errors.full_messages }
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        { character: nil, errors: e.record.errors.full_messages }
+      end
+    end
+  end
+end

--- a/backend/app/graphql/mutations/characters/delete_character.rb
+++ b/backend/app/graphql/mutations/characters/delete_character.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Characters
+    class DeleteCharacter < BaseMutation
+      description "Delete a character"
+
+      argument :id, ID, required: true
+
+      field :success, Boolean, null: false
+      field :errors, [String], null: false
+
+      def resolve(id:)
+        character = Character.find(id)
+        character.destroy
+        { success: true, errors: [] }
+      rescue ActiveRecord::RecordNotFound
+        { success: false, errors: ["Character not found: #{id}"] }
+      end
+    end
+  end
+end

--- a/backend/app/graphql/mutations/characters/update_character.rb
+++ b/backend/app/graphql/mutations/characters/update_character.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Characters
+    class UpdateCharacter < BaseMutation
+      description "Update an existing character"
+
+      argument :id, ID, required: true
+      argument :input, Types::Input::CharacterInputType, required: true
+
+      field :character, Types::CharacterType, null: true
+      field :errors, [String], null: false
+
+      def resolve(id:, input:)
+        character = Character.find(id)
+        if character.update(input.to_h.compact)
+          { character: character, errors: [] }
+        else
+          { character: nil, errors: character.errors.full_messages }
+        end
+      rescue ActiveRecord::RecordNotFound
+        { character: nil, errors: ["Character not found: #{id}"] }
+      rescue ActiveRecord::RecordInvalid => e
+        { character: nil, errors: e.record.errors.full_messages }
+      end
+    end
+  end
+end

--- a/backend/app/graphql/mutations/quests/create_quest.rb
+++ b/backend/app/graphql/mutations/quests/create_quest.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quests
+    class CreateQuest < BaseMutation
+      description "Create a new quest"
+
+      argument :input, Types::Input::QuestInputType, required: true
+
+      field :quest, Types::QuestType, null: true
+      field :errors, [String], null: false
+
+      def resolve(input:)
+        quest = Quest.new(input.to_h.compact)
+        if quest.save
+          { quest: quest, errors: [] }
+        else
+          { quest: nil, errors: quest.errors.full_messages }
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        { quest: nil, errors: e.record.errors.full_messages }
+      end
+    end
+  end
+end

--- a/backend/app/graphql/mutations/quests/delete_quest.rb
+++ b/backend/app/graphql/mutations/quests/delete_quest.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quests
+    class DeleteQuest < BaseMutation
+      description "Delete a quest"
+
+      argument :id, ID, required: true
+
+      field :success, Boolean, null: false
+      field :errors, [String], null: false
+
+      def resolve(id:)
+        quest = Quest.find(id)
+        quest.destroy
+        { success: true, errors: [] }
+      rescue ActiveRecord::RecordNotFound
+        { success: false, errors: ["Quest not found: #{id}"] }
+      end
+    end
+  end
+end

--- a/backend/app/graphql/mutations/quests/update_quest.rb
+++ b/backend/app/graphql/mutations/quests/update_quest.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Quests
+    class UpdateQuest < BaseMutation
+      description "Update an existing quest"
+
+      argument :id, ID, required: true
+      argument :input, Types::Input::QuestInputType, required: true
+
+      field :quest, Types::QuestType, null: true
+      field :errors, [String], null: false
+
+      def resolve(id:, input:)
+        quest = Quest.find(id)
+        if quest.update(input.to_h.compact)
+          { quest: quest, errors: [] }
+        else
+          { quest: nil, errors: quest.errors.full_messages }
+        end
+      rescue ActiveRecord::RecordNotFound
+        { quest: nil, errors: ["Quest not found: #{id}"] }
+      rescue ActiveRecord::RecordInvalid => e
+        { quest: nil, errors: e.record.errors.full_messages }
+      end
+    end
+  end
+end

--- a/backend/app/graphql/mutations/simulation_configs/update_simulation_config.rb
+++ b/backend/app/graphql/mutations/simulation_configs/update_simulation_config.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Mutations
+  module SimulationConfigs
+    class UpdateSimulationConfig < BaseMutation
+      description "Update the simulation configuration (singleton)"
+
+      argument :input, Types::Input::SimulationConfigInputType, required: true
+
+      field :simulation_config, Types::SimulationConfigType, null: true
+      field :errors, [String], null: false
+
+      def resolve(input:)
+        config = SimulationConfig.current
+        if config.update(input.to_h.compact)
+          { simulation_config: config, errors: [] }
+        else
+          { simulation_config: nil, errors: config.errors.full_messages }
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        { simulation_config: nil, errors: e.record.errors.full_messages }
+      end
+    end
+  end
+end

--- a/backend/app/graphql/types/input/artifact_input_type.rb
+++ b/backend/app/graphql/types/input/artifact_input_type.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Types
+  module Input
+    class ArtifactInputType < Types::BaseInputObject
+      description "Input for creating or updating an artifact"
+
+      argument :name, String, required: true
+      argument :artifact_type, String, required: true
+      argument :power, String, required: false
+      argument :corrupted, Boolean, required: false
+      argument :stat_bonus, GraphQL::Types::JSON, required: false
+      argument :character_id, ID, required: false
+    end
+  end
+end

--- a/backend/app/graphql/types/input/character_input_type.rb
+++ b/backend/app/graphql/types/input/character_input_type.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module Input
+    class CharacterInputType < Types::BaseInputObject
+      description "Input for creating or updating a character"
+
+      argument :name, String, required: true
+      argument :race, Types::RaceEnum, required: true
+      argument :realm, String, required: false
+      argument :title, String, required: false
+      argument :ring_bearer, Boolean, required: false
+      argument :level, Integer, required: false
+      argument :xp, Integer, required: false
+      argument :strength, Integer, required: false
+      argument :wisdom, Integer, required: false
+      argument :endurance, Integer, required: false
+      argument :status, Types::CharacterStatusEnum, required: false
+    end
+  end
+end

--- a/backend/app/graphql/types/input/quest_input_type.rb
+++ b/backend/app/graphql/types/input/quest_input_type.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  module Input
+    class QuestInputType < Types::BaseInputObject
+      description "Input for creating or updating a quest"
+
+      argument :title, String, required: true
+      argument :description, String, required: false
+      argument :status, Types::QuestStatusEnum, required: false
+      argument :danger_level, Integer, required: false
+      argument :region, Types::RegionEnum, required: false
+      argument :progress, Float, required: false
+      argument :success_chance, Float, required: false
+      argument :quest_type, Types::QuestTypeEnum, required: false
+      argument :campaign_order, Integer, required: false
+      argument :attempts, Integer, required: false
+    end
+  end
+end

--- a/backend/app/graphql/types/input/simulation_config_input_type.rb
+++ b/backend/app/graphql/types/input/simulation_config_input_type.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Types
+  module Input
+    class SimulationConfigInputType < Types::BaseInputObject
+      description "Input for updating the simulation configuration"
+
+      argument :mode, Types::SimulationModeEnum, required: false
+      argument :running, Boolean, required: false
+      argument :tick_interval_seconds, Integer, required: false
+      argument :progress_min, Float, required: false
+      argument :progress_max, Float, required: false
+      argument :campaign_position, Integer, required: false
+    end
+  end
+end

--- a/backend/app/graphql/types/mutation_type.rb
+++ b/backend/app/graphql/types/mutation_type.rb
@@ -4,7 +4,22 @@ module Types
   class MutationType < Types::BaseObject
     description "The mutation root of this schema"
 
-    # Mutations will be added in Phase 3.4+ (Issue #23)
-    has_no_fields(true)
+    # Characters
+    field :create_character, mutation: Mutations::Characters::CreateCharacter
+    field :update_character, mutation: Mutations::Characters::UpdateCharacter
+    field :delete_character, mutation: Mutations::Characters::DeleteCharacter
+
+    # Quests
+    field :create_quest, mutation: Mutations::Quests::CreateQuest
+    field :update_quest, mutation: Mutations::Quests::UpdateQuest
+    field :delete_quest, mutation: Mutations::Quests::DeleteQuest
+
+    # Artifacts
+    field :create_artifact, mutation: Mutations::Artifacts::CreateArtifact
+    field :update_artifact, mutation: Mutations::Artifacts::UpdateArtifact
+    field :assign_artifact, mutation: Mutations::Artifacts::AssignArtifact
+
+    # SimulationConfig
+    field :update_simulation_config, mutation: Mutations::SimulationConfigs::UpdateSimulationConfig
   end
 end

--- a/backend/spec/graphql/mutations/artifacts_spec.rb
+++ b/backend/spec/graphql/mutations/artifacts_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GraphQL — artifact mutations", type: :request do
+  describe "createArtifact" do
+    it "creates an artifact with valid input" do
+      mutation = <<~GQL
+        mutation {
+          createArtifact(input: {
+            name: "Anduril",
+            artifactType: "sword",
+            corrupted: false
+          }) {
+            artifact { id name artifactType corrupted }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "createArtifact")
+      expect(data["errors"]).to be_empty
+      expect(data["artifact"]["name"]).to eq("Anduril")
+      expect(data["artifact"]["artifactType"]).to eq("sword")
+      expect(data["artifact"]["corrupted"]).to be false
+    end
+
+    it "returns errors for missing name" do
+      mutation = <<~GQL
+        mutation {
+          createArtifact(input: {
+            name: "",
+            artifactType: "ring"
+          }) {
+            artifact { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "createArtifact")
+      expect(data["errors"]).not_to be_empty
+      expect(data["artifact"]).to be_nil
+    end
+
+    it "returns errors for missing artifact_type" do
+      mutation = <<~GQL
+        mutation {
+          createArtifact(input: {
+            name: "Mystery Item",
+            artifactType: ""
+          }) {
+            artifact { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "createArtifact")
+      expect(data["errors"]).not_to be_empty
+      expect(data["artifact"]).to be_nil
+    end
+  end
+
+  describe "updateArtifact" do
+    let!(:artifact) { create(:artifact, name: "Old Sword", artifact_type: "sword", corrupted: false) }
+
+    it "updates an artifact with valid input" do
+      mutation = <<~GQL
+        mutation {
+          updateArtifact(id: #{artifact.id}, input: {
+            name: "Glamdring",
+            artifactType: "sword",
+            corrupted: false
+          }) {
+            artifact { id name artifactType }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateArtifact")
+      expect(data["errors"]).to be_empty
+      expect(data["artifact"]["name"]).to eq("Glamdring")
+    end
+
+    it "returns errors when artifact is not found" do
+      mutation = <<~GQL
+        mutation {
+          updateArtifact(id: 99999, input: {
+            name: "Ghost Sword",
+            artifactType: "sword"
+          }) {
+            artifact { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateArtifact")
+      expect(data["errors"]).not_to be_empty
+      expect(data["artifact"]).to be_nil
+    end
+  end
+
+  describe "assignArtifact" do
+    let!(:character) { create(:character, name: "Gandalf") }
+    let!(:artifact)  { create(:artifact, name: "Glamdring", artifact_type: "sword") }
+
+    it "assigns an artifact to a character" do
+      mutation = <<~GQL
+        mutation {
+          assignArtifact(id: #{artifact.id}, characterId: #{character.id}) {
+            artifact { id name character { id name } }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "assignArtifact")
+      expect(data["errors"]).to be_empty
+      expect(data["artifact"]["character"]["name"]).to eq("Gandalf")
+    end
+
+    it "unassigns an artifact from a character" do
+      artifact.update!(character: character)
+
+      mutation = <<~GQL
+        mutation {
+          assignArtifact(id: #{artifact.id}) {
+            artifact { id name character { id } }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "assignArtifact")
+      expect(data["errors"]).to be_empty
+      expect(data["artifact"]["character"]).to be_nil
+    end
+
+    it "returns errors when artifact is not found" do
+      mutation = <<~GQL
+        mutation {
+          assignArtifact(id: 99999, characterId: #{character.id}) {
+            artifact { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "assignArtifact")
+      expect(data["errors"]).not_to be_empty
+      expect(data["artifact"]).to be_nil
+    end
+  end
+end

--- a/backend/spec/graphql/mutations/characters_spec.rb
+++ b/backend/spec/graphql/mutations/characters_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GraphQL — character mutations", type: :request do
+  describe "createCharacter" do
+    it "creates a character with valid input" do
+      mutation = <<~GQL
+        mutation {
+          createCharacter(input: {
+            name: "Aragorn",
+            race: MAN,
+            level: 10,
+            xp: 500,
+            strength: 15,
+            wisdom: 12,
+            endurance: 14
+          }) {
+            character { id name race level }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "createCharacter")
+      expect(data["errors"]).to be_empty
+      expect(data["character"]["name"]).to eq("Aragorn")
+      expect(data["character"]["race"]).to eq("MAN")
+      expect(data["character"]["level"]).to eq(10)
+    end
+
+    it "returns errors for missing required fields (name blank)" do
+      mutation = <<~GQL
+        mutation {
+          createCharacter(input: {
+            name: "",
+            race: HOBBIT,
+            level: 1,
+            xp: 0,
+            strength: 5,
+            wisdom: 5,
+            endurance: 5
+          }) {
+            character { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "createCharacter")
+      expect(data["errors"]).not_to be_empty
+      expect(data["character"]).to be_nil
+    end
+
+    it "returns errors for invalid level (must be > 0)" do
+      mutation = <<~GQL
+        mutation {
+          createCharacter(input: {
+            name: "Frodo",
+            race: HOBBIT,
+            level: 0,
+            xp: 0,
+            strength: 5,
+            wisdom: 5,
+            endurance: 5
+          }) {
+            character { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "createCharacter")
+      expect(data["errors"]).not_to be_empty
+      expect(data["character"]).to be_nil
+    end
+  end
+
+  describe "updateCharacter" do
+    let!(:character) { create(:character, name: "Boromir", race: "Man", level: 5) }
+
+    it "updates a character with valid input" do
+      mutation = <<~GQL
+        mutation {
+          updateCharacter(id: #{character.id}, input: {
+            name: "Faramir",
+            race: MAN,
+            level: 6,
+            xp: 100,
+            strength: 10,
+            wisdom: 10,
+            endurance: 10
+          }) {
+            character { id name level }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateCharacter")
+      expect(data["errors"]).to be_empty
+      expect(data["character"]["name"]).to eq("Faramir")
+      expect(data["character"]["level"]).to eq(6)
+    end
+
+    it "returns errors when character is not found" do
+      mutation = <<~GQL
+        mutation {
+          updateCharacter(id: 99999, input: {
+            name: "Ghost",
+            race: MAN,
+            level: 1,
+            xp: 0,
+            strength: 5,
+            wisdom: 5,
+            endurance: 5
+          }) {
+            character { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateCharacter")
+      expect(data["errors"]).not_to be_empty
+      expect(data["character"]).to be_nil
+    end
+
+    it "returns errors for invalid update" do
+      mutation = <<~GQL
+        mutation {
+          updateCharacter(id: #{character.id}, input: {
+            name: "",
+            race: MAN,
+            level: 1,
+            xp: 0,
+            strength: 5,
+            wisdom: 5,
+            endurance: 5
+          }) {
+            character { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateCharacter")
+      expect(data["errors"]).not_to be_empty
+      expect(data["character"]).to be_nil
+    end
+  end
+
+  describe "deleteCharacter" do
+    let!(:character) { create(:character, name: "Saruman") }
+
+    it "deletes an existing character" do
+      mutation = <<~GQL
+        mutation {
+          deleteCharacter(id: #{character.id}) {
+            success
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "deleteCharacter")
+      expect(data["success"]).to be true
+      expect(data["errors"]).to be_empty
+      expect(Character.find_by(id: character.id)).to be_nil
+    end
+
+    it "returns errors when character is not found" do
+      mutation = <<~GQL
+        mutation {
+          deleteCharacter(id: 99999) {
+            success
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "deleteCharacter")
+      expect(data["success"]).to be false
+      expect(data["errors"]).not_to be_empty
+    end
+  end
+end

--- a/backend/spec/graphql/mutations/quests_spec.rb
+++ b/backend/spec/graphql/mutations/quests_spec.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GraphQL — quest mutations", type: :request do
+  describe "createQuest" do
+    it "creates a quest with valid input" do
+      mutation = <<~GQL
+        mutation {
+          createQuest(input: {
+            title: "Destroy the One Ring",
+            dangerLevel: 10,
+            questType: CAMPAIGN,
+            status: PENDING,
+            attempts: 0
+          }) {
+            quest { id title dangerLevel status }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "createQuest")
+      expect(data["errors"]).to be_empty
+      expect(data["quest"]["title"]).to eq("Destroy the One Ring")
+      expect(data["quest"]["dangerLevel"]).to eq(10)
+    end
+
+    it "returns errors for missing title" do
+      mutation = <<~GQL
+        mutation {
+          createQuest(input: {
+            title: "",
+            dangerLevel: 5,
+            questType: CAMPAIGN,
+            status: PENDING,
+            attempts: 0
+          }) {
+            quest { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "createQuest")
+      expect(data["errors"]).not_to be_empty
+      expect(data["quest"]).to be_nil
+    end
+
+    it "returns errors for invalid danger_level" do
+      mutation = <<~GQL
+        mutation {
+          createQuest(input: {
+            title: "Bad Quest",
+            dangerLevel: 11,
+            questType: CAMPAIGN,
+            status: PENDING,
+            attempts: 0
+          }) {
+            quest { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "createQuest")
+      expect(data["errors"]).not_to be_empty
+      expect(data["quest"]).to be_nil
+    end
+  end
+
+  describe "updateQuest" do
+    let!(:quest) { create(:quest, title: "Old Quest", danger_level: 3) }
+
+    it "updates a quest with valid input" do
+      mutation = <<~GQL
+        mutation {
+          updateQuest(id: #{quest.id}, input: {
+            title: "New Quest Title",
+            dangerLevel: 7,
+            questType: CAMPAIGN,
+            status: ACTIVE,
+            attempts: 1
+          }) {
+            quest { id title dangerLevel status }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateQuest")
+      expect(data["errors"]).to be_empty
+      expect(data["quest"]["title"]).to eq("New Quest Title")
+      expect(data["quest"]["dangerLevel"]).to eq(7)
+      expect(data["quest"]["status"]).to eq("ACTIVE")
+    end
+
+    it "returns errors when quest is not found" do
+      mutation = <<~GQL
+        mutation {
+          updateQuest(id: 99999, input: {
+            title: "Ghost Quest",
+            dangerLevel: 5,
+            questType: CAMPAIGN,
+            status: PENDING,
+            attempts: 0
+          }) {
+            quest { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateQuest")
+      expect(data["errors"]).not_to be_empty
+      expect(data["quest"]).to be_nil
+    end
+
+    it "returns errors for invalid update" do
+      mutation = <<~GQL
+        mutation {
+          updateQuest(id: #{quest.id}, input: {
+            title: "",
+            dangerLevel: 5,
+            questType: CAMPAIGN,
+            status: PENDING,
+            attempts: 0
+          }) {
+            quest { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateQuest")
+      expect(data["errors"]).not_to be_empty
+      expect(data["quest"]).to be_nil
+    end
+  end
+
+  describe "deleteQuest" do
+    let!(:quest) { create(:quest, title: "Doomed Quest") }
+
+    it "deletes an existing quest" do
+      mutation = <<~GQL
+        mutation {
+          deleteQuest(id: #{quest.id}) {
+            success
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "deleteQuest")
+      expect(data["success"]).to be true
+      expect(data["errors"]).to be_empty
+      expect(Quest.find_by(id: quest.id)).to be_nil
+    end
+
+    it "returns errors when quest is not found" do
+      mutation = <<~GQL
+        mutation {
+          deleteQuest(id: 99999) {
+            success
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "deleteQuest")
+      expect(data["success"]).to be false
+      expect(data["errors"]).not_to be_empty
+    end
+  end
+end

--- a/backend/spec/graphql/mutations/simulation_configs_spec.rb
+++ b/backend/spec/graphql/mutations/simulation_configs_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GraphQL — simulation config mutations", type: :request do
+  describe "updateSimulationConfig" do
+    it "updates the simulation config" do
+      mutation = <<~GQL
+        mutation {
+          updateSimulationConfig(input: {
+            mode: RANDOM,
+            running: true,
+            tickIntervalSeconds: 30
+          }) {
+            simulationConfig { id mode running tickIntervalSeconds }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateSimulationConfig")
+      expect(data["errors"]).to be_empty
+      expect(data["simulationConfig"]["mode"]).to eq("RANDOM")
+      expect(data["simulationConfig"]["running"]).to be true
+      expect(data["simulationConfig"]["tickIntervalSeconds"]).to eq(30)
+    end
+
+    it "returns errors for invalid tick_interval_seconds" do
+      mutation = <<~GQL
+        mutation {
+          updateSimulationConfig(input: {
+            tickIntervalSeconds: 0
+          }) {
+            simulationConfig { id }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateSimulationConfig")
+      expect(data["errors"]).not_to be_empty
+      expect(data["simulationConfig"]).to be_nil
+    end
+
+    it "creates the config if it does not exist and updates it" do
+      SimulationConfig.delete_all
+
+      mutation = <<~GQL
+        mutation {
+          updateSimulationConfig(input: {
+            mode: CAMPAIGN,
+            running: false,
+            tickIntervalSeconds: 60,
+            progressMin: 0.01,
+            progressMax: 0.1,
+            campaignPosition: 0
+          }) {
+            simulationConfig { id mode running }
+            errors
+          }
+        }
+      GQL
+
+      result = gql(mutation)
+
+      expect(result["errors"]).to be_nil
+      data = result.dig("data", "updateSimulationConfig")
+      expect(data["errors"]).to be_empty
+      expect(data["simulationConfig"]["mode"]).to eq("CAMPAIGN")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Implements Phase 3.4: GraphQL Mutations for all domain models.

- Character mutations: createCharacter, updateCharacter, deleteCharacter
- Quest mutations: createQuest, updateQuest, deleteQuest
- Artifact mutations: createArtifact, updateArtifact, assignArtifact
- SimulationConfig mutation: updateSimulationConfig
- Input types defined for all four domain models
- Validation errors surfaced as GraphQL `errors` array (no HTTP 500)
- Delete mutations use `{ success: Boolean!, errors: [String!]! }` pattern
- RSpec specs cover happy path + error cases for all mutations

## Changes
- `backend/app/graphql/mutations/base_mutation.rb` — BaseMutation class
- `backend/app/graphql/mutations/characters/` — create, update, delete
- `backend/app/graphql/mutations/quests/` — create, update, delete
- `backend/app/graphql/mutations/artifacts/` — create, update, assign
- `backend/app/graphql/mutations/simulation_configs/` — update
- `backend/app/graphql/types/input/` — input type definitions for all four models
- `backend/app/graphql/types/mutation_type.rb` — wired up all mutations
- `backend/spec/graphql/mutations/` — RSpec coverage (27 specs, all passing)

## Acceptance Criteria
- [x] Character mutations (createCharacter, updateCharacter, deleteCharacter)
- [x] Quest mutations (createQuest, updateQuest, deleteQuest)
- [x] Artifact mutations (createArtifact, updateArtifact, assignArtifact)
- [x] SimulationConfig mutation (updateSimulationConfig)
- [x] Input types defined for all four domain models
- [x] Validation errors surfaced as GraphQL errors array
- [x] Delete mutations use { success: Boolean!, errors: [String!]! } pattern
- [x] RSpec specs: successful create/update/delete, validation failure, not-found

## Story
Closes #23

## Testing
```
bundle exec rspec spec/graphql/mutations/
```

All 27 mutation specs pass.

-- Devon (HiveLabs developer agent)