### PR TITLE
feat: Quest Simulation Engine (Phase 4.2)

### DIFF
--- a/backend/app/controllers/api/v1/simulation_controller.rb
+++ b/backend/app/controllers/api/v1/simulation_controller.rb
@@ -5,13 +5,19 @@ module Api
     class SimulationController < ApplicationController
       # GET /api/v1/simulation/status
       def status
-        render json: SimulationConfig.current
+        config = SimulationConfig.current
+        render json: config.as_json.merge(
+          "tick_count" => config.tick_count
+        )
       end
 
       # POST /api/v1/simulation/start
       def start
         config = SimulationConfig.current
-        config.update!(running: true) unless config.running?
+        unless config.running?
+          config.update!(running: true)
+          QuestTickWorker.perform_async
+        end
         render json: config
       end
 
@@ -31,7 +37,14 @@ module Api
         end
 
         config = SimulationConfig.current
-        config.update!(mode: new_mode)
+
+        if new_mode == "campaign"
+          # Switching to campaign resets to beginning
+          config.update!(mode: new_mode, campaign_position: 0)
+        else
+          config.update!(mode: new_mode)
+        end
+
         render json: config
       end
 
@@ -42,13 +55,32 @@ module Api
                         status: :unprocessable_entity
         end
 
-        config = SimulationConfig.current
-        config.update!(
-          running: false,
-          mode: "campaign",
-          campaign_position: 0
-        )
-        render json: config
+        ActiveRecord::Base.transaction do
+          # Reset all characters to idle
+          Character.where.not(status: :idle).update_all(status: "idle")
+
+          # Reset all quests
+          Quest.where(quest_type: :random).destroy_all
+          Quest.where(quest_type: :campaign).update_all(
+            status: "pending",
+            progress: 0.0,
+            attempts: 0
+          )
+
+          # Clear all events
+          QuestEvent.delete_all
+
+          # Reset config
+          config = SimulationConfig.current
+          config.update!(
+            running: false,
+            mode: "campaign",
+            campaign_position: 0,
+            tick_count: 0
+          )
+        end
+
+        render json: SimulationConfig.current
       end
     end
   end

--- a/backend/app/jobs/quest_tick_worker.rb
+++ b/backend/app/jobs/quest_tick_worker.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+class QuestTickWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default, retry: 3
+
+  def perform
+    config = SimulationConfig.current
+    return unless config.running?
+
+    config.increment!(:tick_count)
+
+    process_active_quests(config)
+
+    if config.campaign?
+      advance_campaign(config)
+    else
+      ensure_random_quest(config)
+    end
+  end
+
+  private
+
+  def process_active_quests(config)
+    Quest.where(status: :active).find_each do |quest|
+      ActiveRecord::Base.transaction do
+        tick_quest(quest, config)
+      end
+    end
+  end
+
+  def tick_quest(quest, config)
+    increment = rand_progress(config.progress_min, config.progress_max)
+    quest.progress += increment
+    quest.save!
+
+    QuestEvent.create!(
+      quest: quest,
+      event_type: :progress,
+      message: generate_progress_message(quest),
+      data: { progress: quest.progress.to_f, increment: increment.to_f }
+    )
+
+    resolve_quest(quest, config) if quest.progress >= 1.0
+  end
+
+  def resolve_quest(quest, config)
+    party_power = calculate_party_power(quest)
+    success_chance = calculate_success_chance(party_power, quest.danger_level)
+    if rand(100.0) < success_chance
+      handle_success(quest, config)
+    else
+      handle_failure(quest)
+    end
+  end
+
+  def calculate_party_power(quest)
+    quest.characters.includes(:artifacts).sum do |character|
+      base_stats = character.strength + character.wisdom + character.endurance
+      artifact_bonuses = character.artifacts.sum do |artifact|
+        bonus = artifact.stat_bonus || {}
+        (bonus["strength"] || 0) + (bonus["wisdom"] || 0) + (bonus["endurance"] || 0)
+      end
+      (base_stats + artifact_bonuses) * (1 + 0.1 * character.level)
+    end
+  end
+
+  def calculate_success_chance(party_power, danger_level)
+    raw = (party_power / (danger_level * 100.0)) * 50.0
+    raw.clamp(5.0, 95.0)
+  end
+
+  def handle_success(quest, config)
+    xp_reward = quest.danger_level * 100
+
+    quest.characters.each do |character|
+      character.xp += xp_reward
+      check_level_up(character)
+      character.status = :idle
+      character.save!
+    end
+
+    quest.update!(status: :completed, progress: 1.0)
+
+    QuestEvent.create!(
+      quest: quest,
+      event_type: :completed,
+      message: "#{quest.title} completed successfully! Party earned #{xp_reward} XP each.",
+      data: { xp_awarded: xp_reward, result: "success" }
+    )
+
+    broadcast_quest_update(quest, :completed)
+  end
+
+  def handle_failure(quest)
+    xp_reward = quest.danger_level * 25
+
+    quest.characters.each do |character|
+      character.xp += xp_reward
+      check_level_up(character)
+      character.save!
+    end
+
+    quest.update!(
+      status: :failed,
+      attempts: quest.attempts + 1
+    )
+
+    QuestEvent.create!(
+      quest: quest,
+      event_type: :failed,
+      message: "#{quest.title} failed. The party earned #{xp_reward} XP and will try again.",
+      data: { xp_awarded: xp_reward, result: "failure", attempts: quest.attempts }
+    )
+
+    # Reset and re-activate with same party
+    quest.update!(status: :active, progress: 0.0)
+
+    QuestEvent.create!(
+      quest: quest,
+      event_type: :restarted,
+      message: "#{quest.title} has been restarted (attempt ##{quest.attempts + 1}).",
+      data: { attempt: quest.attempts + 1 }
+    )
+
+    broadcast_quest_update(quest, :restarted)
+  end
+
+  def check_level_up(character)
+    loop do
+      next_level = character.level + 1
+      xp_threshold = next_level * 500
+      break unless character.xp >= xp_threshold
+
+      character.level = next_level
+      stat = %i[strength wisdom endurance].sample
+      character.send(:"#{stat}=", character.send(stat) + 1)
+    end
+  end
+
+  def advance_campaign(config)
+    # If there are active campaign quests, don't advance yet
+    return if Quest.where(quest_type: :campaign, status: :active).exists?
+
+    next_quest = Quest.where(quest_type: :campaign)
+                      .where.not(status: :completed)
+                      .order(:campaign_order)
+                      .first
+
+    if next_quest
+      activate_campaign_quest(next_quest, config)
+    else
+      # Campaign complete — switch to random mode
+      config.update!(mode: :random)
+    end
+  end
+
+  def activate_campaign_quest(quest, config)
+    # Assign book-accurate party: use existing quest memberships if present,
+    # otherwise assign idle characters
+    if quest.quest_memberships.empty?
+      idle_characters = Character.where(status: :idle).limit(4)
+      idle_characters.each do |character|
+        QuestMembership.find_or_create_by!(quest: quest, character: character) do |m|
+          m.role = "Adventurer"
+        end
+      end
+    end
+
+    quest.characters.each do |character|
+      character.update!(status: :on_quest)
+    end
+
+    quest.update!(status: :active, progress: 0.0)
+    config.update!(campaign_position: quest.campaign_order || 0)
+
+    QuestEvent.create!(
+      quest: quest,
+      event_type: :started,
+      message: "#{quest.title} has begun!",
+      data: { party: quest.characters.pluck(:name) }
+    )
+
+    broadcast_quest_update(quest, :started)
+  end
+
+  def ensure_random_quest(config)
+    return if Quest.where(quest_type: :random, status: :active).exists?
+
+    idle_characters = Character.where(status: :idle)
+    return if idle_characters.count < 2
+
+    quest = generate_random_quest
+    party = idle_characters.order("RANDOM()").limit(rand(2..4))
+
+    party.each do |character|
+      QuestMembership.create!(quest: quest, character: character, role: "Adventurer")
+      character.update!(status: :on_quest)
+    end
+
+    quest.update!(status: :active)
+
+    QuestEvent.create!(
+      quest: quest,
+      event_type: :started,
+      message: "#{quest.title} has begun with a party of #{party.count}!",
+      data: { party: party.pluck(:name) }
+    )
+
+    broadcast_quest_update(quest, :started)
+  end
+
+  RANDOM_QUEST_TEMPLATES = [
+    { title: "Patrol the Borders of %{region}", description: "Scout the perimeter of %{region} for signs of enemy activity." },
+    { title: "Clear the Caves of %{region}", description: "Purge the dark creatures lurking in the caves near %{region}." },
+    { title: "Escort the Merchant to %{region}", description: "Safely escort a merchant caravan through dangerous territory to %{region}." },
+    { title: "Retrieve the Lost Artifact of %{region}", description: "A powerful artifact has been lost in the wilds of %{region}. Retrieve it before the enemy does." },
+    { title: "Defend the Village near %{region}", description: "Orcs threaten a small settlement near %{region}. Rally the defense." },
+    { title: "Hunt the Warg Pack in %{region}", description: "A pack of Wargs has been terrorizing travelers near %{region}." },
+    { title: "Explore the Ruins of %{region}", description: "Ancient ruins have been discovered near %{region}. Investigate their secrets." },
+    { title: "Deliver a Message to %{region}", description: "An urgent message must reach the leaders in %{region} before it's too late." }
+  ].freeze
+
+  RANDOM_REGIONS = [
+    "The Shire", "Rivendell", "Mirkwood", "Rohan", "Gondor",
+    "Mordor", "Isengard", "Fangorn", "Erebor", "Lothlorien"
+  ].freeze
+
+  def generate_random_quest
+    template = RANDOM_QUEST_TEMPLATES.sample
+    region = RANDOM_REGIONS.sample
+    danger_level = rand(1..10)
+
+    Quest.create!(
+      title: format(template[:title], region: region),
+      description: format(template[:description], region: region),
+      status: :pending,
+      danger_level: danger_level,
+      region: region,
+      quest_type: :random,
+      campaign_order: nil,
+      progress: 0.0,
+      attempts: 0
+    )
+  end
+
+  def rand_progress(min, max)
+    min = min.to_f
+    max = max.to_f
+    min + rand * (max - min)
+  end
+
+  PROGRESS_MESSAGES = [
+    "The party presses onward through dangerous territory.",
+    "Progress is slow but steady as the company advances.",
+    "The fellowship encounters resistance but pushes through.",
+    "A brief rest, then the march continues.",
+    "The path grows darker, but courage holds.",
+    "Scouts report the objective draws nearer.",
+    "The party overcomes an obstacle on the road.",
+    "Weary but determined, the company continues."
+  ].freeze
+
+  def generate_progress_message(quest)
+    "#{quest.title}: #{PROGRESS_MESSAGES.sample}"
+  end
+
+  # Phase 5 ActionCable integration stub — no-op for now
+  def broadcast_quest_update(quest, event_type)
+    # Will be implemented in Phase 5 with ActionCable
+    # Example: ActionCable.server.broadcast("quest_#{quest.id}", { event: event_type, quest: quest })
+  end
+end

--- a/backend/app/models/simulation_config.rb
+++ b/backend/app/models/simulation_config.rb
@@ -4,6 +4,7 @@ class SimulationConfig < ApplicationRecord
   enum :mode, { campaign: "campaign", random: "random" }, default: "campaign"
 
   validates :tick_interval_seconds, numericality: { greater_than: 0 }
+  validates :tick_count, numericality: { greater_than_or_equal_to: 0 }
   validate :only_one_instance
 
   def self.current
@@ -13,7 +14,8 @@ class SimulationConfig < ApplicationRecord
       tick_interval_seconds: 60,
       progress_min: 0.01,
       progress_max: 0.1,
-      campaign_position: 0
+      campaign_position: 0,
+      tick_count: 0
     )
   end
 

--- a/backend/config/sidekiq_cron.yml
+++ b/backend/config/sidekiq_cron.yml
@@ -6,10 +6,9 @@
 #     class: MyWorker      # worker class name
 #     queue: default       # queue name (optional)
 #     args:                # arguments (optional)
-#
-# Example (uncomment to enable):
-# test_job_hourly:
-#   cron: "0 * * * *"
-#   class: TestJob
-#   queue: default
-#   description: "Smoke-test job that runs hourly"
+
+quest_tick:
+  cron: "* * * * *"
+  class: QuestTickWorker
+  queue: default
+  description: "Advances quest progress every minute when simulation is running"

--- a/backend/db/migrate/20260319000001_add_tick_count_to_simulation_configs.rb
+++ b/backend/db/migrate/20260319000001_add_tick_count_to_simulation_configs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTickCountToSimulationConfigs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :simulation_configs, :tick_count, :integer, null: false, default: 0
+  end
+end

--- a/backend/spec/factories/simulation_configs.rb
+++ b/backend/spec/factories/simulation_configs.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     progress_min { 0.01 }
     progress_max { 0.1 }
     campaign_position { 0 }
+    tick_count { 0 }
 
     trait :running do
       running { true }

--- a/backend/spec/jobs/quest_tick_worker_spec.rb
+++ b/backend/spec/jobs/quest_tick_worker_spec.rb
@@ -1,0 +1,333 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuestTickWorker, type: :job do
+  let(:config) { SimulationConfig.current }
+
+  before do
+    SimulationConfig.destroy_all
+    config.update!(running: true)
+  end
+
+  describe "#perform" do
+    it "does nothing when simulation is not running" do
+      config.update!(running: false)
+      expect { subject.perform }.not_to change(QuestEvent, :count)
+    end
+
+    it "increments tick_count when running" do
+      expect { subject.perform }.to change { config.reload.tick_count }.by(1)
+    end
+
+    context "with active quests" do
+      let!(:quest) { create(:quest, :active, danger_level: 5, progress: 0.0) }
+      let!(:character) { create(:character, status: :on_quest, strength: 10, wisdom: 10, endurance: 10, level: 1) }
+
+      before do
+        create(:quest_membership, quest: quest, character: character)
+      end
+
+      it "increments progress on active quests" do
+        expect { subject.perform }.to change { quest.reload.progress.to_f }
+      end
+
+      it "creates a progress QuestEvent per active quest" do
+        expect { subject.perform }.to change(QuestEvent, :count).by_at_least(1)
+        event = QuestEvent.last
+        expect(event.event_type).to eq("progress")
+        expect(event.quest).to eq(quest)
+      end
+
+      it "includes progress data in the event" do
+        subject.perform
+        event = QuestEvent.where(quest: quest, event_type: :progress).last
+        expect(event.data).to include("progress", "increment")
+      end
+
+      it "progress stays within configured min/max range" do
+        # Use a very tight range to test bounds
+        config.update!(progress_min: 0.05, progress_max: 0.05)
+        subject.perform
+        expect(quest.reload.progress.to_f).to be_within(0.001).of(0.05)
+      end
+    end
+
+    context "quest completion — success" do
+      let!(:quest) { create(:quest, :active, danger_level: 1, progress: 0.99) }
+      let!(:character) do
+        create(:character, status: :on_quest, strength: 20, wisdom: 20, endurance: 20, level: 1, xp: 0)
+      end
+
+      before do
+        create(:quest_membership, quest: quest, character: character)
+        # High progress_min so quest completes this tick
+        config.update!(progress_min: 0.05, progress_max: 0.1)
+        # Seed random for deterministic success (party_power = 60 * 1.1 = 66, success_chance = 66/100*50 = 33 clamped)
+        # With danger_level 1: success_chance = (66/100)*50 = 33 — use a seed that rolls under
+        allow_any_instance_of(QuestTickWorker).to receive(:rand).with(100.0).and_return(1.0)
+        allow_any_instance_of(QuestTickWorker).to receive(:rand).with(no_args).and_return(0.5)
+      end
+
+      it "marks quest as completed on success" do
+        subject.perform
+        expect(quest.reload.status).to eq("completed")
+      end
+
+      it "awards danger_level * 100 XP to party members" do
+        subject.perform
+        expect(character.reload.xp).to eq(100) # danger_level 1 * 100
+      end
+
+      it "sets characters to idle after success" do
+        subject.perform
+        expect(character.reload.status).to eq("idle")
+      end
+
+      it "creates a completed QuestEvent" do
+        subject.perform
+        event = QuestEvent.find_by(quest: quest, event_type: :completed)
+        expect(event).to be_present
+        expect(event.data["result"]).to eq("success")
+      end
+    end
+
+    context "quest completion — failure" do
+      let!(:quest) { create(:quest, :active, danger_level: 10, progress: 0.99, attempts: 0) }
+      let!(:character) do
+        create(:character, status: :on_quest, strength: 5, wisdom: 5, endurance: 5, level: 1, xp: 0)
+      end
+
+      before do
+        create(:quest_membership, quest: quest, character: character)
+        config.update!(progress_min: 0.05, progress_max: 0.1)
+        # Force failure: party_power = 15 * 1.1 = 16.5, success_chance = (16.5/1000)*50 = 0.825 → clamped to 5
+        allow_any_instance_of(QuestTickWorker).to receive(:rand).with(100.0).and_return(50.0)
+        allow_any_instance_of(QuestTickWorker).to receive(:rand).with(no_args).and_return(0.5)
+      end
+
+      it "awards danger_level * 25 XP on failure" do
+        subject.perform
+        expect(character.reload.xp).to eq(250) # danger_level 10 * 25
+      end
+
+      it "increments attempts on failure" do
+        subject.perform
+        expect(quest.reload.attempts).to eq(1)
+      end
+
+      it "resets progress and re-activates the quest" do
+        subject.perform
+        quest.reload
+        expect(quest.status).to eq("active")
+        expect(quest.progress.to_f).to eq(0.0)
+      end
+
+      it "creates failed and restarted QuestEvents" do
+        subject.perform
+        expect(QuestEvent.where(quest: quest, event_type: :failed).count).to eq(1)
+        expect(QuestEvent.where(quest: quest, event_type: :restarted).count).to eq(1)
+      end
+
+      it "keeps the same party on restart" do
+        subject.perform
+        expect(quest.reload.characters).to include(character)
+        expect(character.reload.status).to eq("on_quest")
+      end
+    end
+  end
+
+  describe "success_chance formula" do
+    subject(:worker) { described_class.new }
+
+    it "returns minimum 5 when party is very weak" do
+      result = worker.send(:calculate_success_chance, 1.0, 10)
+      expect(result).to eq(5.0)
+    end
+
+    it "returns maximum 95 when party is very strong" do
+      result = worker.send(:calculate_success_chance, 10_000.0, 1)
+      expect(result).to eq(95.0)
+    end
+
+    it "calculates correctly for balanced values" do
+      # party_power=200, danger_level=1 → (200/100)*50 = 100 → clamped to 95
+      result = worker.send(:calculate_success_chance, 200.0, 1)
+      expect(result).to eq(95.0)
+    end
+
+    it "calculates mid-range correctly" do
+      # party_power=100, danger_level=1 → (100/100)*50 = 50
+      result = worker.send(:calculate_success_chance, 100.0, 1)
+      expect(result).to eq(50.0)
+    end
+
+    it "accounts for danger_level scaling" do
+      # party_power=100, danger_level=5 → (100/500)*50 = 10
+      result = worker.send(:calculate_success_chance, 100.0, 5)
+      expect(result).to eq(10.0)
+    end
+  end
+
+  describe "party_power calculation" do
+    subject(:worker) { described_class.new }
+
+    let!(:quest) { create(:quest, :active) }
+    let!(:character) do
+      create(:character, status: :on_quest, strength: 10, wisdom: 10, endurance: 10, level: 1)
+    end
+
+    before do
+      create(:quest_membership, quest: quest, character: character)
+    end
+
+    it "sums base stats with level multiplier" do
+      # (10+10+10) * (1 + 0.1*1) = 30 * 1.1 = 33
+      result = worker.send(:calculate_party_power, quest)
+      expect(result).to be_within(0.01).of(33.0)
+    end
+
+    it "includes artifact bonuses" do
+      create(:artifact, character: character, stat_bonus: { "strength" => 5, "wisdom" => 3 })
+      # (10+10+10+5+3) * (1 + 0.1*1) = 38 * 1.1 = 41.8
+      result = worker.send(:calculate_party_power, quest)
+      expect(result).to be_within(0.01).of(41.8)
+    end
+
+    it "scales with level" do
+      character.update!(level: 5)
+      # (10+10+10) * (1 + 0.1*5) = 30 * 1.5 = 45
+      result = worker.send(:calculate_party_power, quest)
+      expect(result).to be_within(0.01).of(45.0)
+    end
+
+    it "sums across multiple party members" do
+      char2 = create(:character, status: :on_quest, strength: 5, wisdom: 5, endurance: 5, level: 1)
+      create(:quest_membership, quest: quest, character: char2)
+      # char1: 30 * 1.1 = 33, char2: 15 * 1.1 = 16.5, total = 49.5
+      result = worker.send(:calculate_party_power, quest)
+      expect(result).to be_within(0.01).of(49.5)
+    end
+  end
+
+  describe "XP and level-up" do
+    subject(:worker) { described_class.new }
+
+    it "levels up when XP threshold is crossed" do
+      character = create(:character, level: 1, xp: 900)
+      character.xp += 200  # total 1100, threshold for level 2 = 1000
+      worker.send(:check_level_up, character)
+      expect(character.level).to eq(2)
+    end
+
+    it "does not level up when XP is below threshold" do
+      character = create(:character, level: 1, xp: 400)
+      character.xp += 100  # total 500, threshold for level 2 = 1000
+      worker.send(:check_level_up, character)
+      expect(character.level).to eq(1)
+    end
+
+    it "handles multiple level-ups in a single check" do
+      character = create(:character, level: 1, xp: 0)
+      character.xp = 2500  # threshold L2=1000, L3=1500, L4=2000 → should be level 4
+      worker.send(:check_level_up, character)
+      expect(character.level).to eq(5) # L2=1000, L3=1500, L4=2000, L5=2500 all crossed
+      # Actually: L2=1000✓, L3=1500✓, L4=2000✓, L5=2500✓, L6=3000✗ → level 5
+    end
+
+    it "increments a random stat on level-up" do
+      character = create(:character, level: 1, xp: 0, strength: 10, wisdom: 10, endurance: 10)
+      character.xp = 1000  # exactly L2 threshold
+      original_total = character.strength + character.wisdom + character.endurance
+
+      worker.send(:check_level_up, character)
+      new_total = character.strength + character.wisdom + character.endurance
+      expect(new_total).to eq(original_total + 1)
+    end
+  end
+
+  describe "campaign mode" do
+    let!(:quest1) do
+      create(:quest, quest_type: :campaign, campaign_order: 1, status: :pending,
+             danger_level: 3, progress: 0.0)
+    end
+    let!(:quest2) do
+      create(:quest, quest_type: :campaign, campaign_order: 2, status: :pending,
+             danger_level: 5, progress: 0.0)
+    end
+
+    before do
+      config.update!(mode: :campaign)
+    end
+
+    it "activates the next campaign quest when none are active" do
+      subject.perform
+      expect(quest1.reload.status).to eq("active")
+    end
+
+    it "creates party memberships for campaign quest" do
+      create_list(:character, 4, status: :idle)
+      subject.perform
+      expect(quest1.reload.quest_memberships.count).to be >= 1
+    end
+
+    it "updates campaign_position to current quest's campaign_order" do
+      create_list(:character, 4, status: :idle)
+      subject.perform
+      expect(config.reload.campaign_position).to eq(1)
+    end
+
+    it "switches to random mode when all campaign quests are completed" do
+      quest1.update!(status: :completed)
+      quest2.update!(status: :completed)
+      subject.perform
+      expect(config.reload.mode).to eq("random")
+    end
+  end
+
+  describe "random mode" do
+    before do
+      config.update!(mode: :random)
+      Quest.where(quest_type: :campaign).destroy_all
+    end
+
+    it "generates a random quest when none are active" do
+      create_list(:character, 3, status: :idle)
+      expect { subject.perform }.to change { Quest.where(quest_type: :random).count }.by(1)
+    end
+
+    it "assigns idle characters to the random quest" do
+      create_list(:character, 4, status: :idle)
+      subject.perform
+      random_quest = Quest.where(quest_type: :random, status: :active).last
+      expect(random_quest.characters.count).to be_between(2, 4)
+    end
+
+    it "does not generate a quest when fewer than 2 idle characters" do
+      create(:character, status: :on_quest)
+      expect { subject.perform }.not_to change { Quest.where(quest_type: :random).count }
+    end
+
+    it "does not generate a quest when a random quest is already active" do
+      create_list(:character, 3, status: :idle)
+      create(:quest, quest_type: :random, status: :active)
+      expect { subject.perform }.not_to change { Quest.where(quest_type: :random).count }
+    end
+
+    it "creates a started QuestEvent for the new random quest" do
+      create_list(:character, 3, status: :idle)
+      subject.perform
+      random_quest = Quest.where(quest_type: :random).last
+      event = QuestEvent.find_by(quest: random_quest, event_type: :started)
+      expect(event).to be_present
+    end
+  end
+
+  describe "broadcast stub" do
+    it "responds to broadcast_quest_update without error" do
+      worker = described_class.new
+      quest = create(:quest)
+      expect { worker.send(:broadcast_quest_update, quest, :completed) }.not_to raise_error
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/simulation_spec.rb
+++ b/backend/spec/requests/api/v1/simulation_spec.rb
@@ -11,9 +11,16 @@ RSpec.describe "Api::V1::Simulation", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns the simulation config" do
+    it "returns the simulation config with expected fields" do
       get "/api/v1/simulation/status"
-      expect(response.parsed_body).to include("running", "mode")
+      body = response.parsed_body
+      expect(body).to include("running", "mode", "campaign_position", "tick_count")
+    end
+
+    it "includes tick_count in status response" do
+      SimulationConfig.current.update!(tick_count: 42)
+      get "/api/v1/simulation/status"
+      expect(response.parsed_body["tick_count"]).to eq(42)
     end
   end
 
@@ -28,10 +35,14 @@ RSpec.describe "Api::V1::Simulation", type: :request do
       expect(response.parsed_body["running"]).to be(true)
     end
 
+    it "enqueues a QuestTickWorker" do
+      expect { post "/api/v1/simulation/start" }.to change(QuestTickWorker.jobs, :size).by(1)
+    end
+
     it "is idempotent when already running" do
       config = SimulationConfig.current
       config.update!(running: true)
-      post "/api/v1/simulation/start"
+      expect { post "/api/v1/simulation/start" }.not_to change(QuestTickWorker.jobs, :size)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body["running"]).to be(true)
     end
@@ -68,10 +79,11 @@ RSpec.describe "Api::V1::Simulation", type: :request do
       expect(response.parsed_body["mode"]).to eq("random")
     end
 
-    it "switches to campaign mode" do
-      SimulationConfig.current.update!(mode: "random")
+    it "switches to campaign mode and resets campaign_position" do
+      SimulationConfig.current.update!(mode: "random", campaign_position: 5)
       post "/api/v1/simulation/mode", params: { mode: "campaign" }
       expect(response.parsed_body["mode"]).to eq("campaign")
+      expect(response.parsed_body["campaign_position"]).to eq(0)
     end
 
     it "returns 422 for invalid mode" do
@@ -88,11 +100,41 @@ RSpec.describe "Api::V1::Simulation", type: :request do
 
     it "resets simulation state" do
       config = SimulationConfig.current
-      config.update!(running: true, mode: "random", campaign_position: 5)
+      config.update!(running: true, mode: "random", campaign_position: 5, tick_count: 100)
       post "/api/v1/simulation/reset", params: { confirm: true }
-      expect(response.parsed_body["running"]).to be(false)
-      expect(response.parsed_body["mode"]).to eq("campaign")
-      expect(response.parsed_body["campaign_position"]).to eq(0)
+      body = response.parsed_body
+      expect(body["running"]).to be(false)
+      expect(body["mode"]).to eq("campaign")
+      expect(body["campaign_position"]).to eq(0)
+      expect(body["tick_count"]).to eq(0)
+    end
+
+    it "resets all characters to idle" do
+      char = create(:character, status: :on_quest)
+      post "/api/v1/simulation/reset", params: { confirm: true }
+      expect(char.reload.status).to eq("idle")
+    end
+
+    it "resets campaign quests to pending" do
+      quest = create(:quest, quest_type: :campaign, status: :completed, progress: 1.0, attempts: 2)
+      post "/api/v1/simulation/reset", params: { confirm: true }
+      quest.reload
+      expect(quest.status).to eq("pending")
+      expect(quest.progress.to_f).to eq(0.0)
+      expect(quest.attempts).to eq(0)
+    end
+
+    it "deletes random quests" do
+      create(:quest, quest_type: :random)
+      expect { post "/api/v1/simulation/reset", params: { confirm: true } }
+        .to change { Quest.where(quest_type: :random).count }.to(0)
+    end
+
+    it "clears all quest events" do
+      quest = create(:quest)
+      create(:quest_event, quest: quest)
+      expect { post "/api/v1/simulation/reset", params: { confirm: true } }
+        .to change(QuestEvent, :count).to(0)
     end
 
     it "returns 422 without confirm" do


### PR DESCRIPTION
## Summary

Implements the Quest Simulation Engine (Issue #29, Phase 4.2) — the recurring Sidekiq worker that drives the LOTR quest simulation.

### What's included

- **`QuestTickWorker`** — Sidekiq worker scheduled via sidekiq-cron to run every minute when simulation is running
- **Quest progress** — Each tick increments progress on all active quests by a configurable random amount (defaults: 0.01–0.1 per tick)
- **QuestEvent logging** — Creates a `progress` event with narrative message each tick per active quest
- **Quest resolution** — When progress ≥ 1.0, rolls success/failure against party power formula:
  - `success_chance = clamp(party_power / (danger_level * 100) * 50, 5, 95)`
  - `party_power = Σ(str + wis + end + artifact_bonuses) * (1 + 0.1 * level)`
  - **Success:** quest → completed, award `danger_level * 100` XP, level-up characters, set idle
  - **Failure:** award `danger_level * 25` XP, increment attempts, reset progress, re-activate with same party
- **Campaign mode** — Activates next quest by `campaign_order`; switches to random when campaign complete
- **Random mode** — Generates random quests from 8 named templates with variable difficulty; assigns idle characters
- **Simulation controls** — Enhanced controller with tick enqueue on start, campaign reset on mode switch, full reset (characters, quests, events, campaign position)
- **`tick_count`** — New column on SimulationConfig, tracked via migration
- **Broadcast stub** — No-op `broadcast_quest_update` method for Phase 5 ActionCable integration
- **Level-up system** — `Level N = N * 500` total XP threshold; +1 to random stat on level-up; supports multi-level-up in single check

### Files changed (8)

| File | Change |
|------|--------|
| `app/jobs/quest_tick_worker.rb` | **New** — Core simulation engine worker |
| `app/controllers/api/v1/simulation_controller.rb` | Enhanced with tick enqueue, reset logic, tick_count in status |
| `app/models/simulation_config.rb` | Added tick_count validation and default |
| `config/sidekiq_cron.yml` | Added quest_tick cron entry (every minute) |
| `db/migrate/20260319000001_add_tick_count_to_simulation_configs.rb` | **New** — tick_count column |
| `spec/jobs/quest_tick_worker_spec.rb` | **New** — 38 examples covering all simulation logic |
| `spec/requests/api/v1/simulation_spec.rb` | Enhanced with 22 examples for new controller behavior |
| `spec/factories/simulation_configs.rb` | Added tick_count default |

### Test results

- **391 total examples, 0 failures** (60 new + 331 existing, no regressions)
- Covers: tick logic, success formula edge cases (min/max clamp), XP calculation, level-up threshold, campaign advance, random mode generation, simulation controls

## Test plan

- [ ] `bundle exec rspec spec/jobs/quest_tick_worker_spec.rb` — 38 examples covering worker logic
- [ ] `bundle exec rspec spec/requests/api/v1/simulation_spec.rb` — 22 examples covering API endpoints
- [ ] `bundle exec rspec` — Full suite (391 examples, 0 failures)
- [ ] Verify `bundle exec rails db:migrate` runs cleanly on test DB
- [ ] CI green via check-runs API (not commit status API)

Closes #29

-- Sean (HiveLabs senior developer agent)