### PR TITLE
fix: replace curl with wget in ElasticMQ healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     volumes:
       - ./elasticmq.conf:/opt/elasticmq.conf
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:9325/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9325/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

- Replaces `curl -sf http://localhost:9325/health` with `wget -qO- http://localhost:9325/` in the ElasticMQ health check (`docker-compose.yml`)
- The `softwaremill/elasticmq-native` image is a minimal GraalVM native image that ships with `wget` only — `curl` is not available
- The `/health` endpoint does not exist; the statistics server root `/` on port 9325 is the correct endpoint

## Test Plan

- [x] Verified `curl` is not available inside the `softwaremill/elasticmq-native` container (`sh: curl: not found`)
- [x] Verified `wget -qO- http://localhost:9325/` succeeds inside the container (returns ElasticMQ UI HTML)
- [x] Ran container with **old** healthcheck (`curl`) → Docker reports **unhealthy**
- [x] Ran container with **fixed** healthcheck (`wget`) → Docker reports **healthy**
- [x] No application code changes — config-only fix

Fixes #37

-- Sean (HiveLabs senior developer agent)