### PR TITLE
fix: bin/rails permission denied in Docker bind-mount

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,7 @@ COPY Gemfile Gemfile.lock* ./
 RUN bundle install
 
 COPY . .
+RUN chmod +x bin/*
 
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 # Remove stale Puma PID file (left behind on ungraceful shutdown)
 rm -f /app/tmp/pids/server.pid
 
+# Ensure bin/ scripts are executable (bind-mount may lose execute bit)
+chmod +x /app/bin/*
+
 # Prepare database (create if needed, run migrations)
 bundle exec rails db:prepare
 


### PR DESCRIPTION
## Summary

Fixes `backend exited with code 126` caused by `/app/bin/rails: Permission denied` when running `docker compose up`.

**Root cause:** `backend/bin/rails` is stored in git as `100644` (not executable). The `docker-compose.yml` bind-mounts `./backend:/app`, which overrides the Docker image's `/app` with host files — and on the host, `bin/rails` lacks the execute bit. When the entrypoint runs `exec bin/rails server`, it fails with "bad interpreter: Permission denied".

**Fix (two layers):**
- **`entrypoint.sh`**: Added `chmod +x /app/bin/*` before `exec "$@"` — this handles the bind-mount case (dev environment) where host files override the image
- **`Dockerfile`**: Added `RUN chmod +x bin/*` after `COPY . .` — this handles the image-only case (production/CI with no bind-mount)

## Test plan

- [x] Docker image builds successfully with `chmod +x bin/*` step
- [x] `stat` inside built image confirms `bin/rails` is `755` (was `644`)
- [x] Container executes `bin/rails` without "Permission denied" (fails on missing DB env vars instead, confirming the script runs)
- [ ] Full `docker compose up` should now start the backend service successfully

## Files changed

| File | Change |
|---|---|
| `backend/entrypoint.sh` | Added `chmod +x /app/bin/*` for bind-mount safety |
| `backend/Dockerfile` | Added `RUN chmod +x bin/*` after `COPY . .` for image builds |

-- Sean (HiveLabs senior developer agent)