### PR TITLE
fix: resolve Docker Compose startup failures (backend + Shoryuken)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,11 +15,13 @@ SIDEKIQ_WEB_USER=admin
 SIDEKIQ_WEB_PASSWORD=sidekiq_password
 
 # SQS / ElasticMQ (Phase 4.3)
-# For local development, ElasticMQ runs at http://elasticmq:9324 (Docker) or http://localhost:9324.
-# For production, set real AWS credentials and remove SQS_ENDPOINT.
-SQS_QUEUE_URL=http://localhost:9324/000000000000/palantir-queue
+# ──────────────────────────────────────────────────────────────────────────────
+# When using Docker Compose, these are set automatically by docker-compose.yml.
+# Only uncomment these for running Rails OUTSIDE Docker (e.g. bare-metal dev).
+# ──────────────────────────────────────────────────────────────────────────────
+# SQS_QUEUE_URL=http://localhost:9324/000000000000/palantir-queue
+# SQS_ENDPOINT=http://localhost:9324
 SQS_QUEUE_NAME=palantir-queue
-SQS_ENDPOINT=http://localhost:9324
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=dummy
 AWS_SECRET_ACCESS_KEY=dummy

--- a/backend/.gitattributes
+++ b/backend/.gitattributes
@@ -1,0 +1,4 @@
+# Ensure scripts always use LF line endings, even on Windows checkouts.
+# CRLF shebangs cause "bad interpreter" errors inside Docker containers.
+bin/* text eol=lf
+*.sh  text eol=lf

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,4 +24,5 @@ ENTRYPOINT ["entrypoint.sh"]
 
 EXPOSE 3000
 
-CMD ["bin/rails", "server", "-b", "0.0.0.0"]
+# Use bundle exec to bypass shebang issues from bind-mounted scripts
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -4,6 +4,12 @@ set -e
 # Remove stale Puma PID file (left behind on ungraceful shutdown)
 rm -f /app/tmp/pids/server.pid
 
+# Strip Windows CRLF line endings from scripts (bind-mount may carry
+# host line endings; CRLF shebangs cause "bad interpreter" errors)
+if command -v sed > /dev/null 2>&1; then
+  sed -i 's/\r$//' /app/bin/*
+fi
+
 # Ensure bin/ scripts are executable (bind-mount may lose execute bit)
 chmod +x /app/bin/*
 


### PR DESCRIPTION
## Summary

`docker compose up` has two service failures: the backend exits with code 126 and Shoryuken connects to the wrong host. This PR fixes both.

### Bug 1 — Backend crash (exit 126): CRLF shebang in bind-mounted `bin/rails`

The previous fix (cb3d15e) correctly addressed the missing execute bit, but the error persists because the **root cause is CRLF line endings**, not permissions. When `./backend:/app` is bind-mounted from a Windows host (or any checkout with `core.autocrlf=true`), `bin/rails` gets `\r\n` endings. The shebang becomes `#!/usr/bin/env ruby\r` — the kernel can't resolve this interpreter and reports `bad interpreter: Permission denied`.

**Fixes:**
- `entrypoint.sh`: Strip `\r` from all `bin/*` scripts before chmod
- `Dockerfile`: Change CMD from `bin/rails` to `bundle exec rails` (bypasses shebang entirely)
- `.gitattributes`: Enforce LF endings for `bin/*` and `*.sh` files at the git level

### Bug 2 — Shoryuken connects to `localhost:9324` instead of `elasticmq:9324`

`.env.example` ships `SQS_ENDPOINT=http://localhost:9324`. Users who `cp .env.example .env` load this via `env_file: .env` in docker-compose.yml. Although the `environment:` section sets the correct Docker hostname (`elasticmq`), the localhost value can leak through depending on Docker Compose version and variable resolution order.

**Fix:**
- Comment out `SQS_ENDPOINT` and `SQS_QUEUE_URL` in `.env.example` with a clear note that docker-compose.yml handles these automatically
- Users running bare-metal (outside Docker) can uncomment them

### Action required for existing `.env` files

If you already have a `.env` file, **remove or comment out** `SQS_ENDPOINT` and `SQS_QUEUE_URL` — docker-compose.yml sets the correct values.

## Test plan

- [ ] `docker compose down -v && docker compose build --no-cache && docker compose up` — all services start cleanly
- [ ] Backend container stays running, serves requests on port 3000
- [ ] Shoryuken connects to `elasticmq:9324` (check logs for successful queue polling)
- [ ] Verify on a Windows checkout or with `git config core.autocrlf true` that backend still starts

-- Sean (HiveLabs senior developer agent)