### PR TITLE
fix: add missing config.ru to resolve Puma boot failure

### DIFF
--- a/backend/config.ru
+++ b/backend/config.ru
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This file is used by Rack-based servers to start the application.
+
+require_relative "config/environment"
+
+run Rails.application
+Rails.application.load_server


### PR DESCRIPTION
## Summary

- **Adds `backend/config.ru`** — the standard Rack configuration file required by Puma to boot. This file was omitted when the Rails app was originally scaffolded, causing `rails server` to exit immediately with `configuration config.ru not found`.

## Root Cause

When `docker compose up --build` runs, the backend service executes `bundle exec rails server -b 0.0.0.0` (per `Dockerfile` CMD). Rails delegates to Puma, which looks for `config.ru` in the working directory (`/app`). Since this file was never committed, Puma exits with code 1:

```
backend-1 | configuration config.ru not found
backend-1 | Exiting
backend-1 exited with code 1
```

## Fix

Added the standard Rails 8.1 `config.ru` file:

```ruby
require_relative \"config/environment\"

run Rails.application
Rails.application.load_server
```

This is identical to what `rails new --api` generates.

## Regarding Modified Files on Host

The user also reported local file modifications after running `docker compose up`:

| File | Cause | Severity |
|------|-------|----------|
| `backend/bin/rails` | `entrypoint.sh` runs `sed -i 's/\\r$//' /app/bin/*` — CRLF stripping leaks through the bind mount (`./backend:/app`) | Cosmetic — `.gitattributes` already forces `eol=lf`; git should not track these as changes unless `core.autocrlf` is misconfigured on the host |
| `backend/bin/setup` | Same cause as above | Cosmetic |
| `frontend/src/routeTree.gen.ts` | TanStack Router auto-generates this file when the Vite dev server starts (file-based routing) | Expected behavior — this file should be committed when routes change |

These are **not bugs**. The `bin/` modifications are the entrypoint's CRLF safeguard working correctly. If git reports them as changed, running `git checkout -- backend/bin/` will restore them; the `.gitattributes` ensures LF on next checkout.

## Test Plan

- [ ] Run `docker compose up --build` — backend should boot successfully (Puma starts, binds to 0.0.0.0:3000)
- [ ] Hit `http://localhost:3000/health` — should return 200
- [ ] Verify all services start: backend, frontend, postgres, redis, elasticmq, shoryuken
- [ ] CI passes

---
-- Sean (HiveLabs senior developer agent)"