### PR TITLE
feat: Action Cable infrastructure (Phase 5.1)

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -12,6 +12,7 @@ gem "bootsnap", require: false
 gem "tzinfo-data", platforms: %i[windows jruby]
 gem "rswag-api"
 gem "graphql", "~> 2.4"
+gem "redis", "~> 5.0"
 gem "sidekiq", "~> 7.3"
 gem "sidekiq-cron", "~> 2.3"
 gem "shoryuken", "~> 6.2"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.19.2)
     json-schema (6.2.0)
       addressable (~> 2.8)
@@ -251,6 +252,8 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
     redis-client (0.28.0)
       connection_pool
     reline (0.6.3)
@@ -280,14 +283,13 @@ GEM
       json-schema (>= 2.2, < 7.0)
       railties (>= 5.2, < 8.2)
       rspec-core (>= 2.14)
-    jmespath (1.6.2)
     securerandom (0.4.1)
-    shoulda-matchers (6.5.0)
-      activesupport (>= 5.2.0)
     shoryuken (6.2.1)
       aws-sdk-core (>= 2)
       concurrent-ruby
       thor
+    shoulda-matchers (6.5.0)
+      activesupport (>= 5.2.0)
     sidekiq (7.3.9)
       base64
       connection_pool (>= 2.3.0)
@@ -326,6 +328,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  aws-sdk-sqs (~> 1.8)
   bootsnap
   debug
   factory_bot_rails
@@ -336,12 +339,12 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-cors
   rails (~> 8.1)
+  redis (~> 5.0)
   rspec-rails (~> 7.1)
   rswag-api
   rswag-specs
-  shoulda-matchers (~> 6.0)
-  aws-sdk-sqs (~> 1.8)
   shoryuken (~> 6.2)
+  shoulda-matchers (~> 6.0)
   sidekiq (~> 7.3)
   sidekiq-cron (~> 2.3)
   tzinfo-data
@@ -391,6 +394,7 @@ CHECKSUMS
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
+  jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -439,6 +443,7 @@ CHECKSUMS
   railties (8.1.2) sha256=1289ece76b4f7668fc46d07e55cc992b5b8751f2ad85548b7da351b8c59f8055
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
   redis-client (0.28.0) sha256=888892f9cd8787a41c0ece00bdf5f556dfff7770326ce40bb2bc11f1bfec824b
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
@@ -448,10 +453,9 @@ CHECKSUMS
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
   rswag-api (2.17.0) sha256=728b336b65168ab8ab6024b0e5d267b485c22ccdeb9dfbfb6ec3bac423545a13
   rswag-specs (2.17.0) sha256=a3b2bdf6df89f8741fe4a4ee47ceb1e77dc13e1c96bbe07352117d6e61afa9e3
-  jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  shoulda-matchers (6.5.0) sha256=ef6b572b2bed1ac4aba6ab2c5ff345a24b6d055a93a3d1c3bfc86d9d499e3f44
   shoryuken (6.2.1) sha256=95ddc0a717624a54e799d25a0a05100cb5a0c3728a96211935c214faaf16b3b6
+  shoulda-matchers (6.5.0) sha256=ef6b572b2bed1ac4aba6ab2c5ff345a24b6d055a93a3d1c3bfc86d9d499e3f44
   sidekiq (7.3.9) sha256=1108712e1def89002b28e3545d5ae15d4a57ffd4d2c25d97bb1360988826b5a7
   sidekiq-cron (2.3.1) sha256=96ab3da372289a30dc744c1daa2ae2e85960b2444a6f6ed68df1ff7882c44aac
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1

--- a/backend/app/channels/application_cable/channel.rb
+++ b/backend/app/channels/application_cable/channel.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/backend/app/channels/application_cable/connection.rb
+++ b/backend/app/channels/application_cable/connection.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :connection_identifier
+
+    def connect
+      # Stub identity — authentication via OIDC is planned for Phase 6.
+      # For now, assign a random UUID so each connection has a unique identifier
+      # that channels can use without requiring a logged-in user.
+      self.connection_identifier = SecureRandom.uuid
+    end
+  end
+end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -7,6 +7,7 @@ require "active_model/railtie"
 require "active_job/railtie"
 require "active_record/railtie"
 require "action_controller/railtie"
+require "action_cable/engine"
 require "action_mailer/railtie"
 require "rails/test_unit/railtie"
 
@@ -21,6 +22,13 @@ module MordorsEdge
 
     # Application version (referenced by the health endpoint)
     config.version = "0.1.0"
+
+    # Action Cable allowed origins — reads from CABLE_ALLOWED_ORIGINS env var
+    # (comma-separated). Defaults to the Vite frontend dev server.
+    config.action_cable.allowed_request_origins = ENV
+      .fetch("CABLE_ALLOWED_ORIGINS", "http://localhost:5173")
+      .split(",")
+      .map(&:strip)
 
     # Generator defaults: use RSpec, not MiniTest
     config.generators do |g|

--- a/backend/config/cable.yml
+++ b/backend/config/cable.yml
@@ -1,0 +1,14 @@
+# Action Cable adapter configuration.
+# Development and production use Redis (reusing the Phase 4.1 Redis connection).
+# Test uses the async adapter to avoid requiring a running Redis server.
+
+development:
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
+
+test:
+  adapter: test
+
+production:
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,6 +3,9 @@
 require "sidekiq/web"
 
 Rails.application.routes.draw do
+  # Action Cable WebSocket endpoint
+  mount ActionCable.server => "/cable"
+
   # OpenAPI spec (JSON) and Scalar interactive docs
   get "/api/docs",      to: "api/docs#ui",   format: false
   get "/api/docs.json", to: "api/docs#spec",  format: false

--- a/backend/spec/channels/application_cable/connection_spec.rb
+++ b/backend/spec/channels/application_cable/connection_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationCable::Connection, type: :channel do
+  describe "connect" do
+    it "successfully connects and assigns a connection_identifier" do
+      connect "/cable"
+
+      expect(connection.connection_identifier).to be_present
+      expect(connection.connection_identifier).to match(/\A[0-9a-f-]{36}\z/)
+    end
+
+    it "assigns a unique identifier per connection" do
+      connect "/cable"
+      first_id = connection.connection_identifier
+
+      # Disconnect and reconnect to get a new identifier
+      disconnect
+
+      connect "/cable"
+      second_id = connection.connection_identifier
+
+      expect(first_id).not_to eq(second_id)
+    end
+  end
+
+  describe "disconnect" do
+    it "closes the connection cleanly" do
+      connect "/cable"
+      expect { disconnect }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Enables Action Cable in Rails API mode and wires Redis as the cable adapter, establishing the WebSocket foundation that Phase 5.2 (Quest Events Broadcast), 5.3 (Eye of Sauron Broadcast), and 5.4 (Frontend Client) will all build on.

## Changes

| File | Purpose |
|---|---|
| `config/application.rb` | `require "action_cable/engine"` (disabled by API mode by default); `allowed_request_origins` from `CABLE_ALLOWED_ORIGINS` env var |
| `config/cable.yml` | Redis adapter for dev/prod; `test` adapter for CI (no running Redis needed) |
| `app/channels/application_cable/connection.rb` | `Connection` with `SecureRandom.uuid` stub identity (`identified_by :connection_identifier`) — OIDC auth deferred to Phase 6 |
| `app/channels/application_cable/channel.rb` | `Channel` base class |
| `config/routes.rb` | `mount ActionCable.server => "/cable"` |
| `Gemfile` + `Gemfile.lock` | `redis ~> 5.0` (required by the built-in Action Cable Redis adapter) |
| `spec/channels/application_cable/connection_spec.rb` | 3 RSpec tests: connect assigns identifier, each connection gets a unique UUID, disconnect is clean |

## Architectural notes

- **API mode re-enablement**: Rails API mode excludes `action_cable/engine` from the default railties list. It must be `require`d explicitly — not added to `config/application.rb` via `include_all_railties`.
- **Redis DB index**: `cable.yml` uses Redis DB `/1` to keep Action Cable traffic separate from Sidekiq's DB `/0`.
- **Test adapter**: Using `adapter: test` in `cable.yml` for the test environment avoids the need for a real Redis connection during `rspec` (the CI Redis service is still available but not required for channel unit tests).
- **CORS vs allowed_request_origins**: These are separate concerns. The existing `rack-cors` middleware handles HTTP CORS; `action_cable.allowed_request_origins` is Action Cable's own origin check on the WebSocket upgrade handshake.

## Story

Closes #40

## Testing

```bash
bundle exec rspec spec/channels/
# 3 examples, 0 failures

bundle exec rspec
# 426 examples, 0 failures
```

-- Devon (HiveLabs developer agent)