### PR TITLE
feat: Quest Events Real-Time Broadcast (Phase 5.2)

### DIFF
--- a/backend/app/channels/quest_events_channel.rb
+++ b/backend/app/channels/quest_events_channel.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Streams quest lifecycle events to connected clients.
+#
+# Subscribe to all quest events:
+#   { "command": "subscribe", "identifier": "{\"channel\":\"QuestEventsChannel\"}" }
+#
+# Subscribe to a specific quest's events:
+#   { "command": "subscribe", "identifier": "{\"channel\":\"QuestEventsChannel\",\"quest_id\":42}" }
+#
+# Broadcasts are performed by QuestEventBroadcaster — this channel only
+# manages stream subscriptions.
+class QuestEventsChannel < ApplicationCable::Channel
+  def subscribed
+    if quest_id.present?
+      stream_from "quest_events:#{quest_id}"
+    else
+      stream_from "quest_events"
+    end
+  end
+
+  def unsubscribed
+    # No cleanup needed — Action Cable handles stream teardown automatically.
+  end
+
+  private
+
+  def quest_id
+    params["quest_id"]
+  end
+end

--- a/backend/app/jobs/quest_tick_worker.rb
+++ b/backend/app/jobs/quest_tick_worker.rb
@@ -35,12 +35,14 @@ class QuestTickWorker
     quest.progress += increment
     quest.save!
 
-    QuestEvent.create!(
+    event = QuestEvent.create!(
       quest: quest,
       event_type: :progress,
       message: generate_progress_message(quest),
       data: { progress: quest.progress.to_f, increment: increment.to_f }
     )
+
+    QuestEventBroadcaster.broadcast(event)
 
     resolve_quest(quest, config) if quest.progress >= 1.0
   end
@@ -266,9 +268,9 @@ class QuestTickWorker
     "#{quest.title}: #{PROGRESS_MESSAGES.sample}"
   end
 
-  # Phase 5 ActionCable integration stub — no-op for now
+  # Broadcast the most recent quest event over Action Cable.
   def broadcast_quest_update(quest, event_type)
-    # Will be implemented in Phase 5 with ActionCable
-    # Example: ActionCable.server.broadcast("quest_#{quest.id}", { event: event_type, quest: quest })
+    event = quest.quest_events.order(created_at: :desc).first
+    QuestEventBroadcaster.broadcast(event) if event
   end
 end

--- a/backend/app/services/quest_event_broadcaster.rb
+++ b/backend/app/services/quest_event_broadcaster.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Builds a broadcast payload from a QuestEvent and broadcasts it to
+# Action Cable streams.  Each event is sent to:
+#   1. The global "quest_events" stream (all subscribers)
+#   2. The quest-scoped "quest_events:<quest_id>" stream
+#
+# Usage:
+#   QuestEventBroadcaster.broadcast(quest_event)
+#   QuestEventBroadcaster.new(quest_event).broadcast
+class QuestEventBroadcaster
+  GLOBAL_STREAM = "quest_events"
+
+  attr_reader :quest_event
+
+  def initialize(quest_event)
+    @quest_event = quest_event
+  end
+
+  def self.broadcast(quest_event)
+    new(quest_event).broadcast
+  end
+
+  def broadcast
+    payload = build_payload
+
+    ActionCable.server.broadcast(GLOBAL_STREAM, payload)
+    ActionCable.server.broadcast(quest_stream, payload)
+  end
+
+  private
+
+  def quest_stream
+    "#{GLOBAL_STREAM}:#{quest_event.quest_id}"
+  end
+
+  def build_payload
+    quest = quest_event.quest
+
+    {
+      event_type: quest_event.event_type,
+      quest_id: quest.id,
+      quest_name: quest.title,
+      region: quest.region,
+      message: quest_event.message,
+      data: quest_event.data,
+      occurred_at: quest_event.created_at&.iso8601
+    }
+  end
+end

--- a/backend/spec/channels/quest_events_channel_spec.rb
+++ b/backend/spec/channels/quest_events_channel_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuestEventsChannel, type: :channel do
+  describe "#subscribed" do
+    context "without a quest_id parameter" do
+      it "subscribes to the global quest_events stream" do
+        subscribe
+
+        expect(subscription).to be_confirmed
+        expect(subscription).to have_stream_from("quest_events")
+      end
+    end
+
+    context "with a quest_id parameter" do
+      it "subscribes to the quest-scoped stream" do
+        subscribe(quest_id: 42)
+
+        expect(subscription).to be_confirmed
+        expect(subscription).to have_stream_from("quest_events:42")
+      end
+
+      it "does not subscribe to the global stream" do
+        subscribe(quest_id: 42)
+
+        expect(subscription).not_to have_stream_from("quest_events")
+      end
+    end
+  end
+
+  describe "#unsubscribed" do
+    it "unsubscribes without error" do
+      subscribe
+      expect { unsubscribe }.not_to raise_error
+    end
+  end
+end

--- a/backend/spec/services/quest_event_broadcaster_spec.rb
+++ b/backend/spec/services/quest_event_broadcaster_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuestEventBroadcaster do
+  let(:quest) do
+    create(:quest, :active, title: "Destroy the Ring", region: "Mordor")
+  end
+
+  let(:quest_event) do
+    create(:quest_event, :progress,
+      quest: quest,
+      message: "The fellowship advances.",
+      data: { "progress" => 0.5, "increment" => 0.05 })
+  end
+
+  describe ".broadcast" do
+    it "broadcasts to the global quest_events stream" do
+      expect(ActionCable.server).to receive(:broadcast)
+        .with("quest_events", hash_including(event_type: "progress"))
+      expect(ActionCable.server).to receive(:broadcast)
+        .with("quest_events:#{quest.id}", anything)
+
+      described_class.broadcast(quest_event)
+    end
+
+    it "broadcasts to the quest-scoped stream" do
+      expect(ActionCable.server).to receive(:broadcast)
+        .with("quest_events", anything)
+      expect(ActionCable.server).to receive(:broadcast)
+        .with("quest_events:#{quest.id}", hash_including(quest_id: quest.id))
+
+      described_class.broadcast(quest_event)
+    end
+  end
+
+  describe "payload shape" do
+    let(:payload) { nil }
+
+    before do
+      allow(ActionCable.server).to receive(:broadcast) do |_stream, data|
+        # capture last broadcast payload
+        @captured_payload = data
+      end
+
+      described_class.broadcast(quest_event)
+    end
+
+    it "includes event_type" do
+      expect(@captured_payload[:event_type]).to eq("progress")
+    end
+
+    it "includes quest_id" do
+      expect(@captured_payload[:quest_id]).to eq(quest.id)
+    end
+
+    it "includes quest_name" do
+      expect(@captured_payload[:quest_name]).to eq("Destroy the Ring")
+    end
+
+    it "includes region" do
+      expect(@captured_payload[:region]).to eq("Mordor")
+    end
+
+    it "includes message" do
+      expect(@captured_payload[:message]).to eq("The fellowship advances.")
+    end
+
+    it "includes data hash" do
+      expect(@captured_payload[:data]).to eq({ "progress" => 0.5, "increment" => 0.05 })
+    end
+
+    it "includes occurred_at as ISO 8601" do
+      expect(@captured_payload[:occurred_at]).to match(/\A\d{4}-\d{2}-\d{2}T/)
+    end
+  end
+
+  describe "all event types broadcast correctly" do
+    %i[started progress completed failed restarted].each do |event_type_trait|
+      it "broadcasts #{event_type_trait} events" do
+        event = create(:quest_event, event_type_trait, quest: quest)
+
+        expect(ActionCable.server).to receive(:broadcast)
+          .with("quest_events", hash_including(event_type: event_type_trait.to_s))
+        expect(ActionCable.server).to receive(:broadcast)
+          .with("quest_events:#{quest.id}", hash_including(event_type: event_type_trait.to_s))
+
+        described_class.broadcast(event)
+      end
+    end
+  end
+
+  describe "broadcast to empty channel" do
+    it "does not raise when no subscribers are listening" do
+      expect { described_class.broadcast(quest_event) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary\n\nImplement `QuestEventsChannel` and `QuestEventBroadcaster` to stream quest lifecycle events over Action Cable in real time. Builds directly on the Phase 5.1 Action Cable infrastructure (PR #47 / sha 927e2fa).\n\n- **`QuestEventsChannel`** — clients subscribe to the global `quest_events` stream (all events) or a quest-scoped `quest_events:<quest_id>` stream (single quest only)\n- **`QuestEventBroadcaster`** service object — builds a standardised payload (`event_type`, `quest_id`, `quest_name`, `region`, `message`, `data`, `occurred_at`) and broadcasts to both streams\n- **`QuestTickWorker`** wired to broadcast on every quest event: progress ticks, completions, failures, restarts, and quest starts\n- Unsubscribe / connection drop handled gracefully (no errors on broadcast to empty channel)\n\n## Files Changed\n\n| File | Change |\n|------|--------|\n| `backend/app/channels/quest_events_channel.rb` | **New** — Action Cable channel with global + quest-scoped streams |\n| `backend/app/services/quest_event_broadcaster.rb` | **New** — Service object encapsulating broadcast logic |\n| `backend/app/jobs/quest_tick_worker.rb` | **Modified** — replaced no-op stub with live broadcast calls |\n| `backend/spec/channels/quest_events_channel_spec.rb` | **New** — 4 tests (subscribe, scoped stream, no global leak, unsubscribe) |\n| `backend/spec/services/quest_event_broadcaster_spec.rb` | **New** — 15 tests (broadcast targets, payload shape, all event types, empty channel) |\n\n## Test Plan\n\n- [x] 19 new RSpec tests covering channel subscription, stream scoping, payload shape verification, all 5 event types, and graceful empty-channel broadcast\n- [x] Full test suite: **445 tests passing, 0 failures** (verified locally in Docker with Postgres)\n- [ ] CI green on GitHub Actions (use check-runs API to verify)\n\n## Architectural Decisions\n\n- Extracted broadcast logic into `QuestEventBroadcaster` service object rather than inlining in the worker, per issue guidance. Keeps worker thin and makes the broadcaster independently testable and reusable by other workers (e.g., `EyeOfSauronWorker` in Phase 5.3).\n- Dual-stream design: every event goes to both the global stream and the quest-scoped stream. This lets dashboard views consume all events while detail views filter to a single quest.\n- `broadcast_quest_update` in QuestTickWorker looks up the most recent event for the quest to broadcast lifecycle transitions (completed, failed, restarted, started). Progress ticks broadcast the event directly at creation time.\n\nCloses #41\n\n-- Sean (HiveLabs senior developer agent)