### PR TITLE
chore: guard against singleton consumer duplication in useActionCable (Issue #56)

### DIFF
--- a/frontend/src/hooks/useActionCable.test.tsx
+++ b/frontend/src/hooks/useActionCable.test.tsx
@@ -64,4 +64,50 @@ describe('ActionCableProvider / useActionCable', () => {
       renderHook(() => useActionCable());
     }).toThrow('useActionCable must be used inside <ActionCableProvider>');
   });
+
+  it('creates exactly one consumer on mount (no duplicates during initialisation)', () => {
+    renderHook(() => useActionCable(), { wrapper });
+    // Even though the guard runs in the render body, createConsumer must only
+    // ever be called once per mount cycle.
+    expect(mockCreateConsumer).toHaveBeenCalledTimes(1);
+  });
+
+  it('after unmount the consumer is disconnected; remount creates a new consumer (StrictMode-safe)', () => {
+    // First mount
+    const { unmount } = renderHook(() => useActionCable(), { wrapper });
+    expect(mockCreateConsumer).toHaveBeenCalledTimes(1);
+
+    // Unmount — simulates StrictMode cleanup or a genuine provider teardown.
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+
+    // Second mount — the ref was cleared on unmount so a fresh consumer must
+    // be created, not the stale disconnected one.
+    vi.clearAllMocks();
+    renderHook(() => useActionCable(), { wrapper });
+    expect(mockCreateConsumer).toHaveBeenCalledTimes(1);
+    // The previous consumer is already disconnected; the new one is not yet.
+    expect(mockDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('never has two live consumers at the same time (no concurrent duplicates)', () => {
+    // Mount → disconnect (simulates StrictMode cleanup) → remount.
+    // At no point should there be two un-disconnected consumers alive.
+    const { unmount: unmount1 } = renderHook(() => useActionCable(), { wrapper });
+    expect(mockCreateConsumer).toHaveBeenCalledTimes(1);
+    expect(mockDisconnect).toHaveBeenCalledTimes(0);
+
+    // Simulate the StrictMode simulated unmount of the first effect.
+    unmount1();
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+
+    // Remount: only one new consumer is created — not two.
+    vi.clearAllMocks();
+    const { unmount: unmount2 } = renderHook(() => useActionCable(), { wrapper });
+    expect(mockCreateConsumer).toHaveBeenCalledTimes(1);
+    expect(mockDisconnect).toHaveBeenCalledTimes(0); // new consumer still live
+
+    unmount2();
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/hooks/useActionCable.tsx
+++ b/frontend/src/hooks/useActionCable.tsx
@@ -17,9 +17,13 @@ export function ActionCableProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const c = consumerRef.current;
-    // Disconnect cleanly when the provider unmounts (page navigation / unmount).
+    // Disconnect cleanly and clear the ref when the provider unmounts.
+    // Clearing the ref is critical for React StrictMode: after the simulated
+    // cleanup the next render's `if (!consumerRef.current)` guard will create
+    // a fresh consumer instead of reusing the stale, disconnected instance.
     return () => {
       c?.disconnect();
+      consumerRef.current = null;
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes the singleton consumer duplication risk flagged during PR #54 review (Phase 5.4). The `ActionCableProvider` already used a `useRef` guard to prevent creating multiple consumers during the same render. However, the cleanup function called `consumer.disconnect()` but did **not** reset the ref to `null` — leaving a stale disconnected consumer in the ref on unmount.

Under React StrictMode's double-invocation of effects:
1. Component renders → `consumerRef.current = createConsumer(...)` (consumer A)
2. StrictMode cleanup → `c.disconnect()` but `consumerRef.current` still = consumer A (non-null)
3. StrictMode remount → `if (!consumerRef.current)` is **false** → no new consumer created → stale disconnected consumer reused ❌

## Changes

- **`frontend/src/hooks/useActionCable.tsx`** — One-line fix: add `consumerRef.current = null` in the `useEffect` cleanup, after `c?.disconnect()`. This ensures the next render's guard correctly creates a fresh consumer on re-mount.
- **`frontend/src/hooks/useActionCable.test.tsx`** — Added 3 new tests:
  - `creates exactly one consumer on mount (no duplicates during initialisation)`
  - `after unmount the consumer is disconnected; remount creates a new consumer (StrictMode-safe)`
  - `never has two live consumers at the same time (no concurrent duplicates)`

## Testing

All 25 frontend tests pass (5 test files):

```
✓ src/hooks/useActionCable.test.tsx   (8 tests)
✓ src/hooks/useQuestEventsChannel.test.tsx (6 tests)
✓ src/hooks/useSauronGazeChannel.test.tsx  (5 tests)
✓ src/components/PixelSprite.test.tsx      (3 tests)
✓ src/schemas/health.test.ts               (3 tests)
Tests  25 passed (25)
```

## Architectural Note

This is also a prerequisite for clean token-based consumer recreation in Phase 6.4. With the ref reliably cleared on disconnect, Phase 6.4 can safely trigger a reconnect by calling `disconnect()` + null-ing the ref + re-rendering, without risk of leaving an orphaned WebSocket connection open.

Closes #56

-- Devon (HiveLabs developer agent)