### PR TITLE
fix: align SauronGaze TypeScript interface with backend broadcast payload

### DIFF
--- a/frontend/src/hooks/useSauronGazeChannel.test.tsx
+++ b/frontend/src/hooks/useSauronGazeChannel.test.tsx
@@ -57,7 +57,12 @@ describe('useSauronGazeChannel', () => {
     const { result } = renderHook(() => useSauronGazeChannel(), { wrapper });
     expect(result.current.latestGaze).toBeNull();
 
-    const gaze = { intensity: 0.8, target: 'fellowship' };
+    const gaze = {
+      region: 'Mordor',
+      threat_level: 8,
+      message: 'The Eye turns toward Mordor',
+      watched_at: '2026-03-20T12:00:00Z',
+    };
     act(() => capturedCallbacks.received?.(gaze));
     expect(result.current.latestGaze).toEqual(gaze);
   });

--- a/frontend/src/hooks/useSauronGazeChannel.ts
+++ b/frontend/src/hooks/useSauronGazeChannel.ts
@@ -3,9 +3,10 @@ import { useActionCable } from './useActionCable';
 import type { ConnectionStatus } from './useQuestEventsChannel';
 
 export interface SauronGaze {
-  intensity: number;
-  target?: string;
-  [key: string]: unknown;
+  region: string;
+  threat_level: number;
+  message: string;
+  watched_at: string;
 }
 
 export interface UseSauronGazeChannelResult {


### PR DESCRIPTION
## Summary\n\n- Corrects the `SauronGaze` TypeScript interface in `useSauronGazeChannel.ts` to match the actual payload broadcast by `SauronGazeChannel` on the backend\n- Removes stale fields (`intensity`, `target`, index signature) and replaces with actual fields (`region`, `threat_level`, `message`, `watched_at`)\n- Updates Vitest test to use the correct payload shape with realistic values\n\nCloses #55\n\n## Changes\n\n| File | Change |\n|------|--------|\n| `frontend/src/hooks/useSauronGazeChannel.ts` | Interface fields updated to `{ region: string; threat_level: number; message: string; watched_at: string }` |\n| `frontend/src/hooks/useSauronGazeChannel.test.tsx` | Test payload updated to use correct field names |\n\n## Source of truth\n\nBackend (`eye_of_sauron_worker.rb`) is the source of truth for payload shape; frontend interface updated to match.\n\n## Context\n\nSplit from PR #65 which bundled this fix with unrelated OIDC/infra work. This PR contains only the 2-file SauronGaze fix, scoped exactly to Issue #55.\n\n## Testing\n\n- Only 2 files changed — minimal, focused fix\n- Test payload updated to match new interface\n- No regressions in WebSocket subscription logic\n\n-- Sean (HiveLabs senior developer agent)"