### PR TITLE
feat: Eye of Sauron Threat Monitor Panel (Phase 7.4)

### DIFF
--- a/frontend/src/components/SauronHistoryLog.test.tsx
+++ b/frontend/src/components/SauronHistoryLog.test.tsx
@@ -1,0 +1,73 @@
+import { MantineProvider } from '@mantine/core';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { SauronGaze } from '../hooks/useSauronGazeChannel';
+import { SauronHistoryLog } from './SauronHistoryLog';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MantineProvider>{children}</MantineProvider>;
+}
+
+const sampleEvents: SauronGaze[] = [
+  {
+    region: 'Mordor',
+    threat_level: 9,
+    message: 'The Eye burns with fury',
+    watched_at: '2026-03-21T14:05:00Z',
+  },
+  {
+    region: 'The Shire',
+    threat_level: 2,
+    message: 'A gentle gaze drifts over the land',
+    watched_at: '2026-03-21T14:00:00Z',
+  },
+  {
+    region: 'Isengard',
+    threat_level: 6,
+    message: 'Saruman watches from his tower',
+    watched_at: '2026-03-21T13:55:00Z',
+  },
+];
+
+describe('SauronHistoryLog', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows empty state when no events', () => {
+    render(<SauronHistoryLog events={[]} />, { wrapper });
+
+    expect(screen.getByTestId('history-empty')).toBeInTheDocument();
+    expect(screen.getByText(/No events received/)).toBeInTheDocument();
+  });
+
+  it('renders all provided events', () => {
+    render(<SauronHistoryLog events={sampleEvents} />, { wrapper });
+
+    expect(screen.getAllByTestId('history-entry')).toHaveLength(3);
+  });
+
+  it('displays region and message for each entry', () => {
+    render(<SauronHistoryLog events={sampleEvents} />, { wrapper });
+
+    expect(screen.getByText('Mordor')).toBeInTheDocument();
+    expect(screen.getByText('The Shire')).toBeInTheDocument();
+    expect(screen.getByText('Isengard')).toBeInTheDocument();
+    expect(screen.getByText('The Eye burns with fury')).toBeInTheDocument();
+  });
+
+  it('renders the scrollable history log container', () => {
+    render(<SauronHistoryLog events={sampleEvents} />, { wrapper });
+
+    expect(screen.getByTestId('history-log')).toBeInTheDocument();
+  });
+
+  it('shows newest entry first (first item in array)', () => {
+    render(<SauronHistoryLog events={sampleEvents} />, { wrapper });
+
+    const entries = screen.getAllByTestId('history-entry');
+    expect(entries[0]).toHaveTextContent('Mordor');
+    expect(entries[2]).toHaveTextContent('Isengard');
+  });
+});

--- a/frontend/src/components/SauronHistoryLog.tsx
+++ b/frontend/src/components/SauronHistoryLog.tsx
@@ -1,0 +1,67 @@
+import { Badge, Group, Paper, ScrollArea, Stack, Text } from '@mantine/core';
+import type { SauronGaze } from '../hooks/useSauronGazeChannel';
+
+interface SauronHistoryLogProps {
+  events: SauronGaze[];
+}
+
+function threatColor(level: number): string {
+  if (level <= 2) return 'green';
+  if (level <= 4) return 'yellow';
+  if (level <= 6) return 'orange';
+  return 'red';
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString();
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * Scrollable history log showing the most recent Sauron gaze events.
+ * Newest entries appear at the top.
+ */
+export function SauronHistoryLog({ events }: SauronHistoryLogProps) {
+  if (events.length === 0) {
+    return (
+      <Text c="dimmed" size="sm" ta="center" data-testid="history-empty">
+        No events received yet. Waiting for the Eye to stir…
+      </Text>
+    );
+  }
+
+  return (
+    <ScrollArea h={360} data-testid="history-log">
+      <Stack gap="xs">
+        {events.map((event) => (
+          <Paper
+            key={`${event.watched_at}-${event.region}`}
+            p="sm"
+            withBorder
+            data-testid="history-entry"
+          >
+            <Group justify="space-between" wrap="nowrap">
+              <Group gap="xs" wrap="nowrap">
+                <Badge color={threatColor(event.threat_level)} variant="filled" size="sm">
+                  {event.threat_level}
+                </Badge>
+                <Text size="sm" fw={500}>
+                  {event.region}
+                </Text>
+              </Group>
+              <Text size="xs" c="dimmed">
+                {formatTimestamp(event.watched_at)}
+              </Text>
+            </Group>
+            <Text size="xs" c="dimmed" mt={4}>
+              {event.message}
+            </Text>
+          </Paper>
+        ))}
+      </Stack>
+    </ScrollArea>
+  );
+}

--- a/frontend/src/components/ThreatLevelIndicator.test.tsx
+++ b/frontend/src/components/ThreatLevelIndicator.test.tsx
@@ -1,0 +1,39 @@
+import { MantineProvider } from '@mantine/core';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ThreatLevelIndicator } from './ThreatLevelIndicator';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MantineProvider>{children}</MantineProvider>;
+}
+
+describe('ThreatLevelIndicator', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the threat level value', () => {
+    render(<ThreatLevelIndicator level={7} region="Mordor" message="The Eye turns" />, { wrapper });
+    expect(screen.getByTestId('threat-level-value')).toHaveTextContent('7');
+  });
+
+  it('renders the region name', () => {
+    render(<ThreatLevelIndicator level={3} region="The Shire" message="A calm gaze" />, {
+      wrapper,
+    });
+    expect(screen.getByTestId('threat-region')).toHaveTextContent('The Shire');
+  });
+
+  it('renders the message', () => {
+    render(<ThreatLevelIndicator level={5} region="Rivendell" message="Shadows stir" />, {
+      wrapper,
+    });
+    expect(screen.getByTestId('threat-message')).toHaveTextContent('Shadows stir');
+  });
+
+  it('renders the indicator container', () => {
+    render(<ThreatLevelIndicator level={0} region="Rohan" message="Peace" />, { wrapper });
+    expect(screen.getByTestId('threat-indicator')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ThreatLevelIndicator.tsx
+++ b/frontend/src/components/ThreatLevelIndicator.tsx
@@ -1,0 +1,55 @@
+import { Box, RingProgress, Stack, Text } from '@mantine/core';
+
+interface ThreatLevelIndicatorProps {
+  level: number;
+  region: string;
+  message: string;
+}
+
+/**
+ * Maps threat level (0–10) to a colour that transitions from
+ * calm green → amber → urgent red as the Eye focuses.
+ */
+function threatColor(level: number): string {
+  if (level <= 2) return 'green';
+  if (level <= 4) return 'yellow';
+  if (level <= 6) return 'orange';
+  return 'red';
+}
+
+/**
+ * A large, colour-coded ring showing the current threat level
+ * broadcast by the Eye of Sauron.
+ */
+export function ThreatLevelIndicator({ level, region, message }: ThreatLevelIndicatorProps) {
+  const color = threatColor(level);
+  const pct = Math.min(level, 10) * 10; // 0-100 scale for the ring
+
+  return (
+    <Stack align="center" gap="xs" data-testid="threat-indicator">
+      <RingProgress
+        size={200}
+        thickness={16}
+        roundCaps
+        sections={[{ value: pct, color }]}
+        label={
+          <Box ta="center">
+            <Text size="xl" fw={700} data-testid="threat-level-value">
+              {level}
+            </Text>
+            <Text size="xs" c="dimmed">
+              / 10
+            </Text>
+          </Box>
+        }
+      />
+
+      <Text size="lg" fw={600} data-testid="threat-region">
+        {region}
+      </Text>
+      <Text size="sm" c="dimmed" ta="center" maw={360} data-testid="threat-message">
+        {message}
+      </Text>
+    </Stack>
+  );
+}

--- a/frontend/src/routes/_auth/-sauron.test.tsx
+++ b/frontend/src/routes/_auth/-sauron.test.tsx
@@ -1,0 +1,138 @@
+import { MantineProvider } from '@mantine/core';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock the router hooks so we can render SauronPage without a real router.
+// ---------------------------------------------------------------------------
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    createFileRoute: () => (opts: { component: unknown }) => opts,
+    useNavigate: () => vi.fn(),
+    useSearch: () => ({}),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock useSauronGazeChannel so we control channel data.
+// ---------------------------------------------------------------------------
+const mockUseSauronGazeChannel = vi.fn();
+
+vi.mock('../../hooks/useSauronGazeChannel', () => ({
+  useSauronGazeChannel: () => mockUseSauronGazeChannel(),
+}));
+
+// Import the page component AFTER mocks are registered.
+import { SauronPage } from './sauron';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MantineProvider>{children}</MantineProvider>;
+}
+
+const sampleGaze = {
+  region: 'Mordor',
+  threat_level: 8,
+  message: 'The Eye of Sauron turns toward Mordor',
+  watched_at: '2026-03-21T14:00:00Z',
+};
+
+describe('SauronPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows loading state while connecting with no data', () => {
+    mockUseSauronGazeChannel.mockReturnValue({
+      latestGaze: null,
+      connectionStatus: 'connecting',
+    });
+
+    render(<SauronPage />, { wrapper });
+
+    expect(screen.getByTestId('loading-state')).toBeInTheDocument();
+    expect(screen.getByText(/Awaiting signal/)).toBeInTheDocument();
+  });
+
+  it('renders the threat indicator when a gaze is received', () => {
+    mockUseSauronGazeChannel.mockReturnValue({
+      latestGaze: sampleGaze,
+      connectionStatus: 'connected',
+    });
+
+    render(<SauronPage />, { wrapper });
+
+    expect(screen.getByTestId('threat-indicator')).toBeInTheDocument();
+    expect(screen.getByTestId('threat-level-value')).toHaveTextContent('8');
+    expect(screen.getByTestId('threat-region')).toHaveTextContent('Mordor');
+    expect(screen.getByTestId('threat-message')).toHaveTextContent(
+      'The Eye of Sauron turns toward Mordor',
+    );
+  });
+
+  it('shows disconnect banner when WebSocket is disconnected', () => {
+    mockUseSauronGazeChannel.mockReturnValue({
+      latestGaze: null,
+      connectionStatus: 'disconnected',
+    });
+
+    render(<SauronPage />, { wrapper });
+
+    expect(screen.getByTestId('disconnect-banner')).toBeInTheDocument();
+    expect(screen.getByText(/WebSocket connection lost/)).toBeInTheDocument();
+  });
+
+  it('does not show disconnect banner when connected', () => {
+    mockUseSauronGazeChannel.mockReturnValue({
+      latestGaze: sampleGaze,
+      connectionStatus: 'connected',
+    });
+
+    render(<SauronPage />, { wrapper });
+
+    expect(screen.queryByTestId('disconnect-banner')).not.toBeInTheDocument();
+  });
+
+  it('shows cable status indicator', () => {
+    mockUseSauronGazeChannel.mockReturnValue({
+      latestGaze: sampleGaze,
+      connectionStatus: 'connected',
+    });
+
+    render(<SauronPage />, { wrapper });
+
+    expect(screen.getByText('CABLE: CONNECTED')).toBeInTheDocument();
+  });
+
+  it('still shows last known state when disconnected', () => {
+    mockUseSauronGazeChannel.mockReturnValue({
+      latestGaze: sampleGaze,
+      connectionStatus: 'disconnected',
+    });
+
+    render(<SauronPage />, { wrapper });
+
+    // Disconnect banner visible
+    expect(screen.getByTestId('disconnect-banner')).toBeInTheDocument();
+    // But threat data still rendered
+    expect(screen.getByTestId('threat-indicator')).toBeInTheDocument();
+    expect(screen.getByTestId('threat-level-value')).toHaveTextContent('8');
+  });
+
+  it('renders the history section heading when data is present', () => {
+    mockUseSauronGazeChannel.mockReturnValue({
+      latestGaze: sampleGaze,
+      connectionStatus: 'connected',
+    });
+
+    render(<SauronPage />, { wrapper });
+
+    expect(screen.getByText('History')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/_auth/sauron.tsx
+++ b/frontend/src/routes/_auth/sauron.tsx
@@ -1,19 +1,83 @@
-import { Container, Text, Title } from '@mantine/core';
+import { Alert, Center, Container, Group, Loader, Stack, Text, Title } from '@mantine/core';
 import { createFileRoute } from '@tanstack/react-router';
+import { useRef, useState } from 'react';
+import { CableStatus } from '../../components/CableStatus';
+import { SauronHistoryLog } from '../../components/SauronHistoryLog';
+import { ThreatLevelIndicator } from '../../components/ThreatLevelIndicator';
+import { type SauronGaze, useSauronGazeChannel } from '../../hooks/useSauronGazeChannel';
 
 export const Route = createFileRoute('/_auth/sauron')({
   component: SauronPage,
 });
 
-function SauronPage() {
+const MAX_HISTORY = 50;
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+export function SauronPage() {
+  const { latestGaze, connectionStatus } = useSauronGazeChannel();
+  const [history, setHistory] = useState<SauronGaze[]>([]);
+  const prevGazeRef = useRef<SauronGaze | null>(null);
+
+  // Append to history whenever a new gaze arrives.
+  // We compare by reference to the latestGaze object to avoid duplicates.
+  if (latestGaze && latestGaze !== prevGazeRef.current) {
+    prevGazeRef.current = latestGaze;
+    // Prepend newest and cap at MAX_HISTORY — inline to avoid useEffect lag.
+    setHistory((prev) => [latestGaze, ...prev].slice(0, MAX_HISTORY));
+  }
+
   return (
-    <Container>
-      <Title order={2} mb="md">
-        SAURON
-      </Title>
-      <Text c="dimmed" size="sm">
-        Sauron panel coming in Phase 7.4.
-      </Text>
+    <Container size="md">
+      <Group justify="space-between" align="center" mb="md">
+        <Title order={2}>EYE OF SAURON</Title>
+        <CableStatus status={connectionStatus} />
+      </Group>
+
+      {/* Disconnect banner */}
+      {connectionStatus === 'disconnected' && (
+        <Alert
+          color="yellow"
+          title="Real-time updates unavailable"
+          mb="md"
+          data-testid="disconnect-banner"
+        >
+          WebSocket connection lost. Threat data may be stale.
+        </Alert>
+      )}
+
+      {/* Connecting state — no data yet */}
+      {connectionStatus === 'connecting' && !latestGaze && (
+        <Center h={200}>
+          <Stack align="center" gap="xs">
+            <Loader size="lg" />
+            <Text c="dimmed" size="sm" data-testid="loading-state">
+              Awaiting signal from the Eye…
+            </Text>
+          </Stack>
+        </Center>
+      )}
+
+      {/* Live threat indicator */}
+      {latestGaze && (
+        <Stack gap="lg">
+          <ThreatLevelIndicator
+            level={latestGaze.threat_level}
+            region={latestGaze.region}
+            message={latestGaze.message}
+          />
+
+          <Text size="xs" c="dimmed" ta="center">
+            Last update: {new Date(latestGaze.watched_at).toLocaleString()}
+          </Text>
+
+          <Title order={4} mt="sm">
+            History
+          </Title>
+          <SauronHistoryLog events={history} />
+        </Stack>
+      )}
     </Container>
   );
 }


### PR DESCRIPTION
## Summary\n\n- Implements the `/sauron` page with real-time threat monitoring via `SauronGazeChannel` (Authenticated Action Cable, Phase 6.4)\n- Adds `ThreatLevelIndicator` component: colour-coded ring progress (green → yellow → orange → red) reflecting threat level 0–10, plus region and message display\n- Adds `SauronHistoryLog` component: scrollable log of last 50 received gaze events, newest first, with threat level badge, region, message, and timestamp\n- Disconnect warning banner when WebSocket connection drops; last known state remains visible\n- Loading spinner while awaiting initial signal from the Eye\n- Auth-guarded via `_auth` layout (Phase 7.1)\n\n## Technical details\n\n- Uses existing `useSauronGazeChannel` hook (Phase 5.4) — no new channel subscription logic needed\n- History maintained in bounded local `useState` array (capped at 50 entries) with ref-based dedup to avoid duplicate appends\n- All Mantine UI components: `RingProgress`, `ScrollArea`, `Paper`, `Badge`, `Alert`\n- `CableStatus` badge reused from quests page pattern\n\n## Files changed\n\n| File | Change |\n|------|--------|\n| `frontend/src/routes/_auth/sauron.tsx` | Replaced placeholder with full Sauron threat monitor page |\n| `frontend/src/components/ThreatLevelIndicator.tsx` | New — colour-coded ring indicator component |\n| `frontend/src/components/SauronHistoryLog.tsx` | New — scrollable event history log |\n| `frontend/src/routes/_auth/-sauron.test.tsx` | New — 7 page-level tests |\n| `frontend/src/components/ThreatLevelIndicator.test.tsx` | New — 4 component tests |\n| `frontend/src/components/SauronHistoryLog.test.tsx` | New — 5 component tests |\n\n## Test plan\n\n- [x] All 113 frontend tests passing (20 test files)\n- [x] Biome lint clean (0 errors, 0 warnings)\n- [x] Vite build succeeds\n- [ ] CI checks pass on PR\n- [ ] Manual verification: `/sauron` page renders threat indicator, history log populates with incoming gaze events, disconnect banner appears on connection loss\n\nCloses #64\n\n-- Sean (HiveLabs senior developer agent)"