### PR TITLE
fix: widen auth login card so button text does not clip

### DIFF
--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -41,7 +41,7 @@ function LoginPage() {
 
   return (
     <Center h="80vh">
-      <Paper p="xl" w={360} withBorder>
+      <Paper p="xl" miw={420} w={440} withBorder>
         <Stack align="center" gap="lg">
           <Title order={2} ta="center">
             MORDOR'S EDGE


### PR DESCRIPTION
## Summary

- Increase login card from `w={360}` to `w={440} miw={420}` to prevent "SIGN IN WITH OIDC" button text from clipping at the right edge

## Problem

The auth login card was fixed at 360px. With the "Press Start 2P" retro pixel font (applied globally via `theme.ts`), `textTransform: uppercase`, `letterSpacing: 0.05em` on the button, and `p="xl"` padding (~32px each side), only ~296px of content width was available — too narrow for the button label.

## Changes

- `frontend/src/routes/login.tsx`: changed `<Paper p="xl" w={360} ...>` → `<Paper p="xl" miw={420} w={440} ...>`
  - `w={440}` provides 376px of content width — enough for the full button label in the retro font
  - `miw={420}` ensures the card does not shrink below 420px at any standard viewport

## Testing

- Lint: `biome check` — ✅ no issues (64 files checked)
- Tests: `vitest run` — ✅ 113 tests passing (20 test files)
- Build: `vite build` — ✅ successful

## Story link

Closes #76

-- Devon (HiveLabs developer agent)