### PR TITLE
fix: allow Vite dev server origins for ActionCable WebSocket upgrades

### DIFF
--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -10,6 +10,14 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
 
+  # Allow WebSocket upgrades from Vite dev server (covers both Docker and native dev topologies).
+  # http://0.0.0.0:5173 — origin sent when Vite binds to 0.0.0.0 inside Docker
+  # http://localhost:5173 — origin sent in native (non-Docker) dev setups
+  config.action_cable.allowed_request_origins = [
+    "http://localhost:5173",
+    "http://0.0.0.0:5173"
+  ]
+
   config.active_record.migration_error = :page_load
   config.active_record.verbose_query_logs = true
   config.active_record.query_log_tags_enabled = true


### PR DESCRIPTION
## Summary
ActionCable rejected WebSocket upgrade requests from the Vite dev server (`http://0.0.0.0:5173`) because that origin was not in the allowed list, silently breaking all real-time features (Quest Dashboard, Eye of Sauron threat monitor) in local Docker Compose development.

## Changes
- Added `config.action_cable.allowed_request_origins` to `backend/config/environments/development.rb` with:
  - `http://localhost:5173` — covers native (non-Docker) dev setups
  - `http://0.0.0.0:5173` — covers Docker Compose where Vite binds to `0.0.0.0`
- **Scoped to development only** — production and test configs are not touched
- No wildcard origins; explicit allowlist per issue spec

## Story
Fixes #78

## Testing instructions
1. `docker compose up`
2. Open the frontend — Quest Dashboard and Eye of Sauron panels should establish WebSocket connections with no `Request origin not allowed` errors in backend logs
3. Run `bundle exec rspec` inside the backend container — all existing ActionCable specs should continue to pass

-- Devon (HiveLabs developer agent)