### PR TITLE
chore: update Gemfile.lock and schema.rb to match running app state

### DIFF
--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -99,6 +99,9 @@ GEM
     builder (3.3.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cronex (0.15.0)
       tzinfo
@@ -132,6 +135,7 @@ GEM
       base64
       fiber-storage
       logger
+    hashdiff (1.2.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -145,6 +149,8 @@ GEM
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
+    jwt (2.10.2)
+      base64
     logger (1.7.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
@@ -252,12 +258,11 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    redis (5.4.1)
-      redis-client (>= 0.22.0)
     redis-client (0.28.0)
       connection_pool
     reline (0.6.3)
       io-console (~> 0.5)
+    rexml (3.4.4)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -310,6 +315,10 @@ GEM
     unicode (0.4.4.5)
     uri (1.1.1)
     useragent (0.16.11)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -335,11 +344,11 @@ DEPENDENCIES
   faker
   graphiql-rails
   graphql (~> 2.4)
+  jwt (~> 2.9)
   pg (~> 1.5)
   puma (>= 5.0)
   rack-cors
   rails (~> 8.1)
-  redis (~> 5.0)
   rspec-rails (~> 7.1)
   rswag-api
   rswag-specs
@@ -348,6 +357,7 @@ DEPENDENCIES
   sidekiq (~> 7.3)
   sidekiq-cron (~> 2.3)
   tzinfo-data
+  webmock (~> 3.24)
 
 CHECKSUMS
   action_text-trix (2.1.17) sha256=b44691639d77e67169dc054ceacd1edc04d44dc3e4c6a427aa155a2beb4cc951
@@ -374,6 +384,7 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  crack (1.0.1)
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   cronex (0.15.0) sha256=21c794e085fad2951c4f2e279f440340a35ba2297e0b738f22f263f69fbe2186
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
@@ -391,12 +402,14 @@ CHECKSUMS
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   graphiql-rails (1.10.5) sha256=d911486eeac01e125d403a61c04f634cccaff9f8ecee5dc4efce3e7aa11bf5d3
   graphql (2.5.21) sha256=9069249c2ef007409c0b7ae49f95b8f25e108f731b8859499ad090edd529f337
+  hashdiff (1.2.1)
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
+  jwt (2.10.2)
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
@@ -443,9 +456,9 @@ CHECKSUMS
   railties (8.1.2) sha256=1289ece76b4f7668fc46d07e55cc992b5b8751f2ad85548b7da351b8c59f8055
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
-  redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
   redis-client (0.28.0) sha256=888892f9cd8787a41c0ece00bdf5f556dfff7770326ce40bb2bc11f1bfec824b
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rexml (3.4.4)
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
@@ -466,6 +479,7 @@ CHECKSUMS
   unicode (0.4.4.5) sha256=42f294bfc8e186d29da89d1f766071505a20a22776168a31bb3408e03fa7a9d7
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  webmock (3.26.2)
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -1,14 +1,108 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
 # This file is the source Rails uses to define your schema when running `bin/rails
-# db:schema:load`. When creating a new database from scratch, `db:schema:load`
-# tends to be faster and is potentially less error prone than running all of your
-# migrations from scratch.
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 0) do
-  # No tables yet. Data models will be added in Phase 2.
+ActiveRecord::Schema[8.1].define(version: 2026_03_19_000001) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "artifacts", force: :cascade do |t|
+    t.string "artifact_type", null: false
+    t.bigint "character_id"
+    t.boolean "corrupted", default: false, null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.text "power"
+    t.jsonb "stat_bonus", default: {}, null: false
+    t.datetime "updated_at", null: false
+    t.index ["artifact_type"], name: "index_artifacts_on_artifact_type"
+    t.index ["character_id"], name: "index_artifacts_on_character_id"
+    t.index ["corrupted"], name: "index_artifacts_on_corrupted"
+    t.index ["stat_bonus"], name: "index_artifacts_on_stat_bonus", using: :gin
+  end
+
+  create_table "characters", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "endurance", default: 5, null: false
+    t.integer "level", default: 1, null: false
+    t.string "name", null: false
+    t.string "race", null: false
+    t.string "realm"
+    t.boolean "ring_bearer", default: false, null: false
+    t.string "status", default: "idle", null: false
+    t.integer "strength", default: 5, null: false
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.integer "wisdom", default: 5, null: false
+    t.integer "xp", default: 0, null: false
+    t.index ["name"], name: "index_characters_on_name"
+    t.index ["race"], name: "index_characters_on_race"
+    t.index ["status"], name: "index_characters_on_status"
+  end
+
+  create_table "quest_events", force: :cascade do |t|
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.jsonb "data", default: {}, null: false
+    t.string "event_type", null: false
+    t.text "message"
+    t.bigint "quest_id", null: false
+    t.index ["created_at"], name: "index_quest_events_on_created_at"
+    t.index ["data"], name: "index_quest_events_on_data", using: :gin
+    t.index ["event_type"], name: "index_quest_events_on_event_type"
+    t.index ["quest_id"], name: "index_quest_events_on_quest_id"
+  end
+
+  create_table "quest_memberships", force: :cascade do |t|
+    t.bigint "character_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "quest_id", null: false
+    t.string "role"
+    t.datetime "updated_at", null: false
+    t.index ["character_id", "quest_id"], name: "index_quest_memberships_on_character_id_and_quest_id", unique: true
+    t.index ["character_id"], name: "index_quest_memberships_on_character_id"
+    t.index ["quest_id"], name: "index_quest_memberships_on_quest_id"
+  end
+
+  create_table "quests", force: :cascade do |t|
+    t.integer "attempts", default: 0, null: false
+    t.integer "campaign_order"
+    t.datetime "created_at", null: false
+    t.integer "danger_level", default: 1, null: false
+    t.text "description"
+    t.decimal "progress", precision: 5, scale: 4, default: "0.0", null: false
+    t.string "quest_type", default: "campaign", null: false
+    t.string "region"
+    t.string "status", default: "pending", null: false
+    t.decimal "success_chance", precision: 5, scale: 4
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["campaign_order"], name: "index_quests_on_campaign_order"
+    t.index ["quest_type"], name: "index_quests_on_quest_type"
+    t.index ["status"], name: "index_quests_on_status"
+  end
+
+  create_table "simulation_configs", force: :cascade do |t|
+    t.integer "campaign_position", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.string "mode", default: "campaign", null: false
+    t.decimal "progress_max", precision: 6, scale: 4, default: "0.1", null: false
+    t.decimal "progress_min", precision: 6, scale: 4, default: "0.01", null: false
+    t.boolean "running", default: false, null: false
+    t.integer "tick_count", default: 0, null: false
+    t.integer "tick_interval_seconds", default: 60, null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "artifacts", "characters"
+  add_foreign_key "quest_events", "quests"
+  add_foreign_key "quest_memberships", "characters"
+  add_foreign_key "quest_memberships", "quests"
 end


### PR DESCRIPTION
## Summary

- **`Gemfile.lock`** — Add missing gems (`jwt`, `webmock`, `crack`, `hashdiff`, `rexml`) introduced by the dev-auth-bypass feature (PR #81). Remove standalone `redis` gem (replaced by `redis-client`).
- **`schema.rb`** — Replace the Phase 1 stub placeholder with the full 6-table database schema generated by running migrations (version `2026_03_19_000001`), covering: `artifacts`, `characters`, `quest_events`, `quest_memberships`, `quests`, and `simulation_configs`.

These files were regenerated when the local Docker Compose stack ran but were not included in previous PRs.

> `frontend/package-lock.json` was also flagged but is already in sync with upstream — no changes needed.

## Test plan

- [ ] CI passes (no functional changes, just lockfile/schema sync)
- [ ] `bundle install` produces no diff against committed `Gemfile.lock`
- [ ] `rails db:schema:dump` produces no diff against committed `schema.rb`

---
-- Sean (HiveLabs senior developer agent)