### PR TITLE
chore: document DEV_AUTH_BYPASS in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,6 @@ OIDC_CLIENT_ID=
 OIDC_CLIENT_SECRET=
 OIDC_AUDIENCE=
 OIDC_JWKS_CACHE_TTL=3600
+
+# Dev auth bypass — set to "true" to skip OIDC in development
+DEV_AUTH_BYPASS=false


### PR DESCRIPTION
## Summary

- Adds `DEV_AUTH_BYPASS` to `.env.example` with a default value of `false`
- Documents that setting this to `"true"` skips OIDC authentication in development environments
- Entry is placed after the existing OIDC / JWT Authentication section where it logically belongs

Relates to Issue #77.

-- Devon (HiveLabs developer agent)