### PR TITLE
fix: add crash detection to Docker Compose smoke test backend probe

### DIFF
--- a/.github/workflows/docker-compose-smoke.yml
+++ b/.github/workflows/docker-compose-smoke.yml
@@ -63,6 +63,15 @@ jobs:
           echo "Waiting for backend (entrypoint: bundle install + db:prepare + server start)..."
           timeout 600 bash -c '
             until curl -sf http://localhost:3000/api/health > /dev/null 2>&1; do
+              # Bail immediately if the backend container has exited unexpectedly
+              # (e.g. a failed bundle install, db:prepare error, or crash at boot).
+              # Without this check the loop spins silently for the full 600 s,
+              # making a crash look like a timeout.
+              if [ -n "$(docker compose ps --status exited -q backend 2>/dev/null)" ]; then
+                echo "ERROR: backend container exited unexpectedly. Last 100 log lines:"
+                docker compose logs --tail=100 backend
+                exit 1
+              fi
               echo "  backend: waiting..."
               sleep 5
             done


### PR DESCRIPTION
## Summary

- The "Wait for backend to be ready" step in `docker-compose-smoke.yml` polls `http://localhost:3000/api/health` every 5 s with a 600 s outer timeout. When the backend container **exits during startup** (crashed bundle install, failed db:prepare, Rails boot error, etc.) the loop spins silently for the full 10 minutes, then reports a generic timeout rather than the real cause.
- Add a `docker compose ps --status exited` check inside the poll loop. If the backend container has exited, we bail immediately and dump the last 100 lines of backend logs before failing.

## Context

Diagnosed while investigating the stuck run on PR #84 (run ID 23413256899). The backend never became healthy within 600 s; the "Dump logs on failure" step ran but the generic all-services log tail makes it hard to isolate the root cause. This change surfaces the real error immediately instead of waiting for a full timeout.

## Changes

- `.github/workflows/docker-compose-smoke.yml`: add container-exit guard inside the backend readiness poll loop

## Test plan

- [ ] Smoke test continues to pass when the backend starts normally (no behaviour change in the happy path)
- [ ] When the backend container crashes at startup, CI now fails fast (seconds, not 10 minutes) and prints backend logs in the step output

-- Devon (HiveLabs developer agent)