### PR TITLE
docs: add OIDC environment variable examples to .env.deploy.example

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -35,3 +35,33 @@ REDIS_URL=redis://redis:6379/0
 
 # Optional: Application host (used for URL generation)
 # APP_HOST=example.com
+
+# =============================================================================
+# OIDC / Authentication (Phase 6)
+# Configure these to point at your OIDC provider (Keycloak, Auth0, Dex, etc.)
+# Introduced by Issues #51-#53 / PRs #57, #60, #67.
+# =============================================================================
+
+# Base URL of your OIDC issuer — must match the `iss` claim in JWTs
+# Example (Keycloak): https://auth.example.com/realms/myrealm
+# Example (Auth0):    https://your-tenant.us.auth0.com/
+OIDC_ISSUER_URL=https://auth.example.com/realms/myrealm
+
+# OAuth2 client ID registered with your OIDC provider
+OIDC_CLIENT_ID=experiment-rfhbx
+
+# OAuth2 client secret — obtain from your OIDC provider's admin console
+# KEEP THIS SECRET; never commit the real value
+OIDC_CLIENT_SECRET=<your-oidc-client-secret>
+
+# Expected `aud` (audience) claim in access tokens
+# Typically matches OIDC_CLIENT_ID, but verify with your provider
+OIDC_AUDIENCE=experiment-rfhbx
+
+# How long (seconds) to cache the provider's JWKS public keys locally
+# Reduces outbound requests to the JWKS endpoint; default is 3600 (1 hour)
+OIDC_JWKS_CACHE_TTL=3600
+
+# Dev auth bypass — MUST be false (or omitted) in production
+# Set to "true" only in development/test to skip OIDC token validation
+DEV_AUTH_BYPASS=false


### PR DESCRIPTION
## Summary

Adds an `# OIDC / Authentication` section to `.env.deploy.example`, documenting all env vars introduced during Phase 6 OIDC work (Issues #51–#53, PRs #57, #60, #67).

## Changes

- Added `# OIDC / Authentication (Phase 6)` section header to `.env.deploy.example`
- Added and documented the following variables:
  - `OIDC_ISSUER_URL` — OIDC provider base URL; must match `iss` claim in JWTs
  - `OIDC_CLIENT_ID` — OAuth2 client ID registered with the provider
  - `OIDC_CLIENT_SECRET` — OAuth2 client secret (placeholder, never real value)
  - `OIDC_AUDIENCE` — expected `aud` claim in access tokens
  - `OIDC_JWKS_CACHE_TTL` — JWKS cache duration in seconds (default: 3600)
  - `DEV_AUTH_BYPASS` — documented as must-be-false in production
- Each variable has an inline comment explaining purpose, expected format, and example values
- Style is consistent with existing entries in the file and mirrors the OIDC section in `.env.example`

## Story

Closes #87

## Testing instructions

- Verify `.env.deploy.example` renders clearly on GitHub
- Confirm all vars match those referenced in the codebase (`ENV.fetch(...)` / `ENV[...]` calls related to OIDC)
- Confirm no duplicates or conflicts with existing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Devon (HiveLabs developer agent)