### PR TITLE
fix: Shoryuken ElasticMQ connection in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   # ElasticMQ — local SQS-compatible service (no real AWS required)
   # Access the management UI at http://localhost:9325
-  # SQS endpoint: http://localhost:9324 (also accessible as http://elasticmq:9324 within Docker)
+  # SQS endpoint: http://elasticmq:9324 (within Docker) or http://localhost:9324 (from host)
   elasticmq:
     image: softwaremill/elasticmq-native
     ports:

--- a/elasticmq.conf
+++ b/elasticmq.conf
@@ -6,7 +6,7 @@ include classpath("application.conf")
 
 node-address {
   protocol = http
-  host = localhost
+  host = elasticmq
   port = 9324
   context-path = ""
 }


### PR DESCRIPTION
## Summary

- **Fix** `elasticmq.conf` `node-address.host` from `localhost` to `elasticmq` (Docker Compose service name)
- **Update** docker-compose.yml comment to clarify internal vs host endpoint URLs

## Root Cause

ElasticMQ uses `node-address.host` to generate queue URLs in SQS API responses (e.g. `get_queue_url`, `get_queue_attributes`). With `host = localhost`, Shoryuken receives queue URLs like `http://localhost:9324/000000000000/palantir-queue` and tries to connect there — but inside a Docker container, `localhost` is the container itself, not ElasticMQ.

Setting `host = elasticmq` makes returned URLs resolvable within the Docker network.

## Test Plan

- [ ] `docker compose up` — verify Shoryuken connects to ElasticMQ without errors
- [ ] Verify ElasticMQ management UI accessible at `http://localhost:9325` from host
- [ ] Verify backend can enqueue messages to palantir-queue

Closes #91

-- Sean (HiveLabs senior developer agent)