### PR TITLE
fix: expose DEV_AUTH_BYPASS to Vite and auto-authenticate on bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,5 +28,11 @@ OIDC_CLIENT_SECRET=
 OIDC_AUDIENCE=
 OIDC_JWKS_CACHE_TTL=3600
 
-# Dev auth bypass — set to "true" to skip OIDC in development
+# Dev auth bypass — set to "true" to skip OIDC in development.
+# This single flag controls BOTH the backend (Rails) and the frontend (Vite):
+#   • Backend: Rails middleware checks ENV["DEV_AUTH_BYPASS"] directly.
+#   • Frontend: vite.config.ts reads DEV_AUTH_BYPASS via loadEnv() and
+#     forwards it as import.meta.env.VITE_DEV_AUTH_BYPASS so the React app
+#     sees it without requiring a separate VITE_DEV_AUTH_BYPASS entry.
+# NEVER set this to "true" in production.
 DEV_AUTH_BYPASS=false

--- a/frontend/src/auth/AuthContext.test.tsx
+++ b/frontend/src/auth/AuthContext.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, renderHook, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -129,5 +129,119 @@ describe('AuthProvider', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() => renderHook(() => useAuth())).toThrow('useAuth must be used inside <AuthProvider>');
     spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dev-bypass auto-login tests
+// ---------------------------------------------------------------------------
+
+describe('AuthProvider — DEV_AUTH_BYPASS auto-login', () => {
+  const devAuthResponse = {
+    token: 'dev-bypass-token',
+    user: { sub: 'dev-user', email: 'dev@mordors-edge.local', name: 'Dev User' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: no existing OIDC session.
+    mockGetUser.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllEnvs();
+  });
+
+  it('calls devLogin automatically on mount when VITE_DEV_AUTH_BYPASS is "true"', async () => {
+    vi.stubEnv('VITE_DEV_AUTH_BYPASS', 'true');
+
+    // Stub fetch so devLogin() succeeds.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => devAuthResponse,
+    } as Response);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    // Wait for loading to complete and the auto-login to fire.
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/dev/auth',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(result.current.devUser).toEqual(devAuthResponse.user);
+    expect(result.current.getAccessToken()).toBe('dev-bypass-token');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('does NOT call devLogin automatically when VITE_DEV_AUTH_BYPASS is not "true"', async () => {
+    vi.stubEnv('VITE_DEV_AUTH_BYPASS', 'false');
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // fetch should not have been called for dev auth.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('does NOT call devLogin again when already authenticated in bypass mode', async () => {
+    vi.stubEnv('VITE_DEV_AUTH_BYPASS', 'true');
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => devAuthResponse,
+    } as Response);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    // Wait for first auto-login to complete.
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    const callCount = fetchSpy.mock.calls.length;
+
+    // Trigger a re-render; devLogin should not be called again.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(fetchSpy.mock.calls.length).toBe(callCount);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('logs an error and stays unauthenticated when devLogin fails in bypass mode', async () => {
+    vi.stubEnv('VITE_DEV_AUTH_BYPASS', 'true');
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    } as Response);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    // Give the async devLogin error path time to settle.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[AuthContext] Auto dev-login failed:',
+      expect.any(Error),
+    );
+    expect(result.current.isAuthenticated).toBe(false);
+
+    fetchSpy.mockRestore();
+    consoleSpy.mockRestore();
   });
 });

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -204,6 +204,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const isAuthenticated = (!!user && !user.expired) || !!devToken;
 
+  // ---------------------------------------------------------------------------
+  // Auto-login when DEV_AUTH_BYPASS is active
+  // ---------------------------------------------------------------------------
+  // If the bypass flag is set, call devLogin() automatically on mount so the
+  // developer never sees the OIDC login screen.  We guard against re-calling
+  // once already authenticated (devToken set) and wait until the loading phase
+  // has completed so we don't race with an existing OIDC session restore.
+  const isDevBypass = import.meta.env.VITE_DEV_AUTH_BYPASS === 'true';
+
+  useEffect(() => {
+    if (isDevBypass && !isLoading && !isAuthenticated) {
+      devLogin().catch((err: unknown) => {
+        console.error('[AuthContext] Auto dev-login failed:', err);
+      });
+    }
+  }, [isLoading, isAuthenticated, devLogin]);
+
   const value: AuthContextValue = {
     user,
     devUser,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,24 +1,42 @@
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 import react from '@vitejs/plugin-react-swc';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
-const apiTarget = process.env.VITE_API_BASE_URL || 'http://localhost:3000';
+export default defineConfig(({ mode }) => {
+  // Load ALL env vars (not just VITE_-prefixed ones) so we can forward
+  // DEV_AUTH_BYPASS from the root .env into the browser bundle.
+  const env = loadEnv(mode, process.cwd(), '');
 
-export default defineConfig({
-  plugins: [
-    TanStackRouterVite({
-      routesDirectory: './src/routes',
-      generatedRouteTree: './src/routeTree.gen.ts',
-    }),
-    react(),
-  ],
-  server: {
-    host: true,
-    proxy: {
-      '/api': {
-        target: apiTarget,
-        changeOrigin: true,
+  const apiTarget = env.VITE_API_BASE_URL || 'http://localhost:3000';
+
+  // Resolve the bypass flag: honour whichever variable the developer has set.
+  // DEV_AUTH_BYPASS (no prefix, root .env) takes precedence over the
+  // VITE_-prefixed variant so that a single root .env entry is enough.
+  const devAuthBypass = env.DEV_AUTH_BYPASS || env.VITE_DEV_AUTH_BYPASS || 'false';
+
+  return {
+    plugins: [
+      TanStackRouterVite({
+        routesDirectory: './src/routes',
+        generatedRouteTree: './src/routeTree.gen.ts',
+      }),
+      react(),
+    ],
+    define: {
+      // Forward DEV_AUTH_BYPASS (root .env, no VITE_ prefix) to the browser
+      // bundle as import.meta.env.VITE_DEV_AUTH_BYPASS.  This means setting
+      // DEV_AUTH_BYPASS=true in the root .env is sufficient to activate the
+      // dev-bypass flow in both the backend and the frontend.
+      'import.meta.env.VITE_DEV_AUTH_BYPASS': JSON.stringify(devAuthBypass),
+    },
+    server: {
+      host: true,
+      proxy: {
+        '/api': {
+          target: apiTarget,
+          changeOrigin: true,
+        },
       },
     },
-  },
+  };
 });


### PR DESCRIPTION
## Summary

- **`frontend/vite.config.ts`**: Converted to factory form and added `loadEnv()` with an empty prefix so all env vars (not just `VITE_`-prefixed) are loaded. A `define` block forwards `DEV_AUTH_BYPASS` (root `.env`, no prefix) as `import.meta.env.VITE_DEV_AUTH_BYPASS` in the browser bundle. `DEV_AUTH_BYPASS` takes precedence; `VITE_DEV_AUTH_BYPASS` in `frontend/.env` continues to work as a fallback.
- **`frontend/src/auth/AuthContext.tsx`**: Added a `useEffect` that calls `devLogin()` automatically on mount when `VITE_DEV_AUTH_BYPASS === 'true'` and the user is not yet authenticated. This means the OIDC login screen is skipped entirely — the dev session is established before the route guard ever renders the login page.
- **`frontend/src/auth/AuthContext.test.tsx`**: Added a new `describe` block with four tests: auto-login happy path, no-bypass path, idempotency guard (devLogin not called again when already authenticated), and error-logging path when `devLogin()` fails.
- **`.env.example`**: Updated the `DEV_AUTH_BYPASS` comment to document that this single flag now controls both the Rails backend and the Vite frontend.

Closes #92

## Test plan

- [ ] Copy `.env.example` to `.env`, set `DEV_AUTH_BYPASS=true`, start the stack (`docker compose up`) — the frontend should authenticate automatically as `dev@mordors-edge.local` without ever showing the OIDC login screen.
- [ ] With `DEV_AUTH_BYPASS=false` (or unset), the normal OIDC login button appears as before.
- [ ] `cd frontend && npm run test` — all 117 tests pass, including the 4 new bypass tests.
- [ ] `cd frontend && npm run lint` — no errors.
- [ ] `cd frontend && npm run build` — build succeeds.

-- Devon (HiveLabs developer agent)