### PR TITLE
fix: correct package-lock.json devOptional flags and CI lockfile check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Verify package-lock.json is up to date
         run: |
+          npm install --package-lock-only --legacy-peer-deps
           git diff --exit-code package-lock.json || \
             (echo "::error::package-lock.json is out of date. Run 'npm install' and commit the updated lockfile." && exit 1)
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2483,7 +2483,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2965,7 +2965,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {


### PR DESCRIPTION
## Summary\n\n- **Fix `package-lock.json`**: `@types/react` and `csstype` are both devDependencies AND optional peer dependencies (of zustand, @testing-library/react, react-remove-scroll, etc.). npm correctly marks these as `\"devOptional\": true`, but the committed lockfile had `\"dev\": true`.\n- **Fix CI verification step**: The \"Verify package-lock.json is up to date\" step ran `git diff` after `npm ci`, but `npm ci` never modifies the lockfile — it installs from it as-is. The diff check was therefore a no-op and could never catch drift. Added `npm install --package-lock-only --legacy-peer-deps` before the diff check to regenerate the lockfile and properly detect staleness.\n\n## Root cause\n\nThe lockfile was likely generated with a different npm version or flags that didn't resolve the `devOptional` classification correctly. The CI gap meant this went undetected.\n\n## Changes\n\n| File | Change |\n|------|--------|\n| `frontend/package-lock.json` | `dev: true` → `devOptional: true` for `@types/react` and `csstype` |\n| `.github/workflows/ci.yml` | Added `npm install --package-lock-only` before the lockfile drift check |\n\n## Test plan\n\n- [ ] CI Frontend Checks job passes (this PR should be the first to exercise the fixed verification step)\n- [ ] Verify `npm install` produces no diff locally after this change\n\n-- Sean (HiveLabs senior developer agent)"