### PR TITLE
fix: use location.searchStr in AuthenticatedLayout returnTo (#105)

### DIFF
--- a/frontend/src/routes/_auth.test.tsx
+++ b/frontend/src/routes/_auth.test.tsx
@@ -1,0 +1,144 @@
+import { MantineProvider } from '@mantine/core';
+import { cleanup, render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mutable location state — updated per test before render.
+// Named with "mock" prefix so Vitest hoists them with vi.mock factories.
+// ---------------------------------------------------------------------------
+const mockNavigate = vi.fn();
+let mockLocation = {
+  pathname: '/quests',
+  searchStr: '',
+  search: {} as Record<string, unknown>,
+};
+let mockAuthState = { isLoading: false, isAuthenticated: false };
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    // createFileRoute returns a function that returns the options object so
+    // we can access Route.component in tests.
+    createFileRoute: () => (opts: unknown) => opts,
+    Outlet: (): null => null,
+    useNavigate: () => mockNavigate,
+    useRouterState: ({ select }: { select: (s: { location: unknown }) => unknown }) =>
+      select({ location: mockLocation }),
+  };
+});
+
+vi.mock('../auth/AuthProvider', () => ({
+  useAuth: () => mockAuthState,
+}));
+
+vi.mock('../auth/authGuard', () => ({
+  requireAuth: vi.fn(),
+}));
+
+// Import AFTER vi.mock calls so the mocks are in place.
+import { Route } from './_auth';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const AuthenticatedLayout = (Route as any).component as () => ReactElement | null;
+
+describe('AuthenticatedLayout — returnTo redirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthState = { isLoading: false, isAuthenticated: false };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('builds a plain pathname returnTo when there are no query params', () => {
+    mockLocation = { pathname: '/quests', searchStr: '', search: {} };
+
+    render(
+      <MantineProvider>
+        <AuthenticatedLayout />
+      </MantineProvider>,
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/login',
+        search: { returnTo: '/quests' },
+      }),
+    );
+
+    const { returnTo } = mockNavigate.mock.calls[0][0].search as { returnTo: string };
+    expect(typeof returnTo).toBe('string');
+    expect(returnTo).not.toContain('[object');
+  });
+
+  it('appends raw query string to returnTo when query params are present', () => {
+    mockLocation = {
+      pathname: '/fellowship',
+      searchStr: '?ring=one&bearer=frodo',
+      search: { ring: 'one', bearer: 'frodo' },
+    };
+
+    render(
+      <MantineProvider>
+        <AuthenticatedLayout />
+      </MantineProvider>,
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/login',
+        search: { returnTo: '/fellowship?ring=one&bearer=frodo' },
+      }),
+    );
+  });
+
+  it('returnTo is always a string, never serialised as [object Object]', () => {
+    // Simulate what the old buggy code would have done: location.search is an object.
+    mockLocation = {
+      pathname: '/dashboard',
+      searchStr: '?tab=active',
+      search: { tab: 'active' },
+    };
+
+    render(
+      <MantineProvider>
+        <AuthenticatedLayout />
+      </MantineProvider>,
+    );
+
+    const call = mockNavigate.mock.calls[0]?.[0] as { search: { returnTo: string } };
+    expect(call).toBeDefined();
+    expect(typeof call.search.returnTo).toBe('string');
+    expect(call.search.returnTo).toBe('/dashboard?tab=active');
+    expect(call.search.returnTo).not.toMatch(/\[object/);
+  });
+
+  it('does NOT call navigate when already authenticated', () => {
+    mockAuthState = { isLoading: false, isAuthenticated: true };
+    mockLocation = { pathname: '/quests', searchStr: '', search: {} };
+
+    render(
+      <MantineProvider>
+        <AuthenticatedLayout />
+      </MantineProvider>,
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call navigate while auth is still loading', () => {
+    mockAuthState = { isLoading: true, isAuthenticated: false };
+    mockLocation = { pathname: '/quests', searchStr: '', search: {} };
+
+    render(
+      <MantineProvider>
+        <AuthenticatedLayout />
+      </MantineProvider>,
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/routes/_auth.tsx
+++ b/frontend/src/routes/_auth.tsx
@@ -22,12 +22,13 @@ function AuthenticatedLayout() {
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
+      const searchStr = location.searchStr ?? '';
       navigate({
         to: '/login',
-        search: { returnTo: location.pathname + location.search },
+        search: { returnTo: location.pathname + searchStr },
       });
     }
-  }, [isLoading, isAuthenticated, navigate, location.pathname, location.search]);
+  }, [isLoading, isAuthenticated, navigate, location.pathname, location.searchStr]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary

- **Root cause**: `location.search` in TanStack Router is a parsed object (`Record<string, unknown>`), not a raw string. Concatenating it with `location.pathname` on line 27 produced `[object Object]` in the `returnTo` redirect value, crashing `AuthenticatedLayout` when an unauthenticated user navigated to a protected route.
- **Fix**: Replace `location.search` with `location.searchStr ?? ''` — TanStack Router's raw query string (e.g. `?foo=bar`, or empty string when no params). Updated the `useEffect` dependency array accordingly.
- **Tests**: 5 new tests added in `_auth.test.tsx` covering: no-param pathname, query string preservation, `[object Object]` regression guard, authenticated pass-through, and loading pass-through. All 122 tests pass.

## Changes

- `frontend/src/routes/_auth.tsx` — one-line fix + dependency array update
- `frontend/src/routes/_auth.test.tsx` — new test file (5 tests)

## Testing Instructions

```bash
cd frontend
npm ci
npx vitest run
```

All 122 tests should pass with 0 failures.

Closes #105

-- Devon (HiveLabs developer agent)