### PR TITLE
ci: auto-retry Docker Compose Smoke Test on backend readiness timeout

### DIFF
--- a/.github/workflows/docker-compose-smoke.yml
+++ b/.github/workflows/docker-compose-smoke.yml
@@ -14,7 +14,7 @@ jobs:
   smoke-test:
     name: Docker Compose Integration
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
 
     steps:
       - name: Checkout
@@ -59,36 +59,30 @@ jobs:
           echo "  elasticmq: ready ✓"
 
       - name: Wait for backend to be ready
-        run: |
-          echo "Waiting for backend (entrypoint: bundle install + db:prepare + server start)..."
-          for i in 1 2 3; do
-            echo "  backend: health-check attempt $i (polling up to 300s)..."
-            if timeout 300 bash -c '
-              until curl -sf http://localhost:3000/api/health > /dev/null 2>&1; do
-                # Bail immediately if the backend container has exited unexpectedly
-                # (e.g. a failed bundle install, db:prepare error, or crash at boot).
-                # Without this check the loop spins silently for the full timeout,
-                # making a crash look like a timeout.
-                if [ -n "$(docker compose ps --status exited -q backend 2>/dev/null)" ]; then
-                  echo "ERROR: backend container exited unexpectedly. Last 100 log lines:"
-                  docker compose logs --tail=100 backend
-                  exit 1
-                fi
-                echo "  backend: waiting..."
-                sleep 5
-              done
-            '; then
-              echo "  backend: ready ✓"
-              break
-            fi
-            echo "  backend: attempt $i timed out"
-            if [ "$i" -eq 3 ]; then
-              echo "All retries exhausted. Backend failed to start."
-              exit 1
-            fi
-            echo "  backend: retrying in 10s..."
-            sleep 10
-          done
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 8
+          max_attempts: 3
+          retry_on: error
+          on_retry_command: |
+            docker compose down -v
+            docker compose up -d
+          command: |
+            echo "Waiting for backend (entrypoint: bundle install + db:prepare + server start)..."
+            until curl -sf http://localhost:3000/api/health > /dev/null 2>&1; do
+              # Bail immediately if the backend container has exited unexpectedly
+              # (e.g. a failed bundle install, db:prepare error, or crash at boot).
+              # Without this check the loop spins silently for the full timeout,
+              # making a crash look like a timeout.
+              if [ -n "$(docker compose ps --status exited -q backend 2>/dev/null)" ]; then
+                echo "ERROR: backend container exited unexpectedly. Last 100 log lines:"
+                docker compose logs --tail=100 backend
+                exit 1
+              fi
+              echo "  backend: waiting..."
+              sleep 5
+            done
+            echo "  backend: ready ✓"
 
       - name: Wait for frontend to be ready
         run: |


### PR DESCRIPTION
## Summary

- Replace the manual `for i in 1 2 3` inner retry loop in the **Wait for backend to be ready** step with `nick-fields/retry@v3` (3 attempts, 8 min per attempt)
- On each retry: tear down the full stack (`docker compose down -v`) and restart it (`docker compose up -d`) for a clean environment
- Increase job `timeout-minutes` from 20 → 35 to accommodate up to 3 full retry cycles (3 × ~8 min + overhead)
- All other steps (infra healthchecks, smoke assertions, log dump on failure, teardown) are unchanged

## Changes

- `.github/workflows/docker-compose-smoke.yml`
  - `timeout-minutes: 20` → `timeout-minutes: 35`
  - "Wait for backend to be ready" step converted from `run:` with inner for-loop to `uses: nick-fields/retry@v3` with `max_attempts: 3`, `timeout_minutes: 8`, `retry_on: error`, and `on_retry_command` that does `docker compose down -v && docker compose up -d`

## Story

Closes #107

## Testing instructions

- PR CI (Docker Compose Smoke Test) should run and pass green
- On a transient backend readiness timeout, the step will automatically retry up to 3 times with a clean stack instead of failing the whole job

-- Devon (HiveLabs developer agent)