### PR TITLE
fix: show empty state when connected but no broadcast received yet

### DIFF
--- a/frontend/src/routes/_auth/-sauron.test.tsx
+++ b/frontend/src/routes/_auth/-sauron.test.tsx
@@ -60,7 +60,21 @@ describe('SauronPage', () => {
     expect(screen.getByText(/Awaiting signal/)).toBeInTheDocument();
   });
 
-  it('renders the threat indicator when a gaze is received', () => {
+  it('shows empty state when connected but no broadcast received yet', () => {
+    mockUseSauronGazeChannel.mockReturnValue({
+      latestGaze: null,
+      connectionStatus: 'connected',
+    });
+
+    render(<SauronPage />, { wrapper });
+
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    expect(screen.getByText(/No threat activity detected/)).toBeInTheDocument();
+    expect(screen.queryByTestId('loading-state')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('disconnect-banner')).not.toBeInTheDocument();
+  });
+
+  it('replaces empty state with threat indicator when a gaze arrives', () => {
     mockUseSauronGazeChannel.mockReturnValue({
       latestGaze: sampleGaze,
       connectionStatus: 'connected',

--- a/frontend/src/routes/_auth/sauron.tsx
+++ b/frontend/src/routes/_auth/sauron.tsx
@@ -59,6 +59,15 @@ export function SauronPage() {
         </Center>
       )}
 
+      {/* Connected but no broadcast received yet */}
+      {connectionStatus === 'connected' && !latestGaze && (
+        <Center h={200}>
+          <Text c="dimmed" size="sm" data-testid="empty-state">
+            No threat activity detected. Watching…
+          </Text>
+        </Center>
+      )}
+
       {/* Live threat indicator */}
       {latestGaze && (
         <Stack gap="lg">


### PR DESCRIPTION
## Summary

- Adds a `connected + no data` empty state to `SauronPage` that renders when `connectionStatus === 'connected'` and `latestGaze === null`
- The empty state shows "No threat activity detected. Watching…" and is visually distinct from the spinner shown during the `connecting` phase
- Once `latestGaze` arrives via broadcast, the empty state is replaced by the threat indicator with no flicker
- All existing states (`connecting`, `disconnected`, live-data) are unchanged

## Changes

- `frontend/src/routes/_auth/sauron.tsx` — new JSX block for the `connected + no data` case, guarded by `connectionStatus === 'connected' && !latestGaze`
- `frontend/src/routes/_auth/-sauron.test.tsx` — new test `shows empty state when connected but no broadcast received yet` covering `data-testid="empty-state"`, and renamed the threat-indicator test for clarity

## Story

Closes #114

## Testing instructions

1. Open the Eye of Sauron page while the ActionCable connection is up but no `SauronGazeChannel` broadcast has been sent
2. Confirm "No threat activity detected. Watching…" is displayed (not a blank page)
3. Trigger a broadcast — confirm the empty state is replaced by the threat indicator
4. Disconnect the WebSocket — confirm the yellow disconnect banner still appears
5. Run `npx vitest run` in `frontend/` — all 126 tests should pass

-- Devon (HiveLabs developer agent)