### PR TITLE
fix: quest auto-start when no quest is active (#120)

### DIFF
--- a/backend/app/jobs/quest_auto_start_worker.rb
+++ b/backend/app/jobs/quest_auto_start_worker.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+# QuestAutoStartWorker is responsible for starting the next available quest
+# immediately when no quest is currently in progress. It is triggered:
+#
+#   1. On Sidekiq startup (boot-time safety net)
+#   2. After a quest completes successfully (via QuestTickWorker)
+#   3. As a sidekiq-cron safety-net job (every 5 minutes)
+#
+# The worker is idempotent: if a quest is already active for the current mode,
+# it exits immediately without doing any work. A short-lived Redis lock prevents
+# duplicate activations when multiple instances run concurrently.
+class QuestAutoStartWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :critical, retry: 3
+
+  # Redis key / TTL for the distributed idempotency lock.
+  LOCK_KEY = "quest_auto_start_lock"
+  LOCK_TTL = 30 # seconds
+
+  def perform
+    config = SimulationConfig.current
+    return unless config.running?
+
+    # Fast path: skip if a quest is already active for the current mode.
+    return if active_quest_for_mode?(config)
+
+    # Acquire a short-lived distributed lock so that concurrent calls (e.g. on
+    # a multi-threaded Sidekiq server) don't race to start the same quest.
+    acquired = Sidekiq.redis { |r| r.set(LOCK_KEY, 1, nx: true, ex: LOCK_TTL) }
+    return unless acquired
+
+    begin
+      if config.campaign?
+        advance_campaign(config)
+      else
+        ensure_random_quest(config)
+      end
+    ensure
+      Sidekiq.redis { |r| r.del(LOCK_KEY) }
+    end
+  end
+
+  private
+
+  # Returns true when there is already an active quest in the mode that is
+  # currently selected, meaning no action is needed.
+  def active_quest_for_mode?(config)
+    if config.campaign?
+      Quest.where(quest_type: :campaign, status: :active).exists?
+    else
+      Quest.where(quest_type: :random, status: :active).exists?
+    end
+  end
+
+  # Activates the next pending campaign quest, or switches to random mode when
+  # all campaign quests have been completed.
+  def advance_campaign(config)
+    # Guard: a campaign quest may have been started between the fast-path check
+    # and lock acquisition.
+    return if Quest.where(quest_type: :campaign, status: :active).exists?
+
+    next_quest = Quest.where(quest_type: :campaign)
+                      .where.not(status: :completed)
+                      .order(:campaign_order)
+                      .first
+
+    if next_quest
+      activate_campaign_quest(next_quest, config)
+    else
+      # All campaign quests are done — switch to random mode and immediately
+      # start the first random quest so there is no idle period.
+      config.update!(mode: :random)
+      ensure_random_quest(config)
+    end
+  end
+
+  # Sets up party memberships, transitions the quest to :active, and broadcasts
+  # the started event.
+  def activate_campaign_quest(quest, config)
+    if quest.quest_memberships.empty?
+      idle_characters = Character.where(status: :idle).limit(4)
+      idle_characters.each do |character|
+        QuestMembership.find_or_create_by!(quest: quest, character: character) do |m|
+          m.role = "Adventurer"
+        end
+      end
+    end
+
+    quest.characters.each { |character| character.update!(status: :on_quest) }
+    quest.update!(status: :active, progress: 0.0)
+    config.update!(campaign_position: quest.campaign_order || 0)
+
+    event = QuestEvent.create!(
+      quest: quest,
+      event_type: :started,
+      message: "#{quest.title} has begun!",
+      data: { party: quest.characters.pluck(:name) }
+    )
+
+    QuestEventBroadcaster.broadcast(event)
+  end
+
+  # Generates a new random quest and assigns idle characters if at least two are
+  # available.
+  def ensure_random_quest(config) # rubocop:disable Lint/UnusedMethodArgument
+    # Guard: a random quest may have been started between the fast-path check
+    # and lock acquisition.
+    return if Quest.where(quest_type: :random, status: :active).exists?
+
+    idle_characters = Character.where(status: :idle)
+    return if idle_characters.count < 2
+
+    quest = generate_random_quest
+    party = idle_characters.order("RANDOM()").limit(rand(2..4))
+
+    party.each do |character|
+      QuestMembership.create!(quest: quest, character: character, role: "Adventurer")
+      character.update!(status: :on_quest)
+    end
+
+    quest.update!(status: :active)
+
+    event = QuestEvent.create!(
+      quest: quest,
+      event_type: :started,
+      message: "#{quest.title} has begun with a party of #{party.count}!",
+      data: { party: party.pluck(:name) }
+    )
+
+    QuestEventBroadcaster.broadcast(event)
+  end
+
+  RANDOM_QUEST_TEMPLATES = [
+    { title: "Patrol the Borders of %{region}",
+      description: "Scout the perimeter of %{region} for signs of enemy activity." },
+    { title: "Clear the Caves of %{region}",
+      description: "Purge the dark creatures lurking in the caves near %{region}." },
+    { title: "Escort the Merchant to %{region}",
+      description: "Safely escort a merchant caravan through dangerous territory to %{region}." },
+    { title: "Retrieve the Lost Artifact of %{region}",
+      description: "A powerful artifact has been lost in the wilds of %{region}. Retrieve it before the enemy does." },
+    { title: "Defend the Village near %{region}",
+      description: "Orcs threaten a small settlement near %{region}. Rally the defense." },
+    { title: "Hunt the Warg Pack in %{region}",
+      description: "A pack of Wargs has been terrorizing travelers near %{region}." },
+    { title: "Explore the Ruins of %{region}",
+      description: "Ancient ruins have been discovered near %{region}. Investigate their secrets." },
+    { title: "Deliver a Message to %{region}",
+      description: "An urgent message must reach the leaders in %{region} before it's too late." }
+  ].freeze
+
+  RANDOM_REGIONS = [
+    "The Shire", "Rivendell", "Mirkwood", "Rohan", "Gondor",
+    "Mordor", "Isengard", "Fangorn", "Erebor", "Lothlorien"
+  ].freeze
+
+  def generate_random_quest
+    template = RANDOM_QUEST_TEMPLATES.sample
+    region = RANDOM_REGIONS.sample
+    danger_level = rand(1..10)
+
+    Quest.create!(
+      title: format(template[:title], region: region),
+      description: format(template[:description], region: region),
+      status: :pending,
+      danger_level: danger_level,
+      region: region,
+      quest_type: :random,
+      campaign_order: nil,
+      progress: 0.0,
+      attempts: 0
+    )
+  end
+end

--- a/backend/app/jobs/quest_tick_worker.rb
+++ b/backend/app/jobs/quest_tick_worker.rb
@@ -93,6 +93,12 @@ class QuestTickWorker
     )
 
     broadcast_quest_update(quest, :completed)
+
+    # Immediately enqueue auto-start so the next quest begins without waiting
+    # for the next cron tick.  The worker is idempotent: if advance_campaign /
+    # ensure_random_quest below already starts the next quest in this same tick,
+    # QuestAutoStartWorker will detect the active quest and exit early.
+    QuestAutoStartWorker.perform_async
   end
 
   def handle_failure(quest)
@@ -153,8 +159,10 @@ class QuestTickWorker
     if next_quest
       activate_campaign_quest(next_quest, config)
     else
-      # Campaign complete — switch to random mode
+      # Campaign complete — switch to random mode and immediately try to start a
+      # random quest in the same tick rather than waiting for the next cron run.
       config.update!(mode: :random)
+      ensure_random_quest(config)
     end
   end
 
@@ -187,7 +195,7 @@ class QuestTickWorker
     broadcast_quest_update(quest, :started)
   end
 
-  def ensure_random_quest(config)
+  def ensure_random_quest(config) # rubocop:disable Lint/UnusedMethodArgument
     return if Quest.where(quest_type: :random, status: :active).exists?
 
     idle_characters = Character.where(status: :idle)

--- a/backend/config/initializers/sidekiq.rb
+++ b/backend/config/initializers/sidekiq.rb
@@ -40,6 +40,12 @@ Sidekiq.configure_server do |config|
     rendered = ERB.new(File.read(cron_schedule_file)).result
     Sidekiq::Cron::Job.load_from_hash(YAML.safe_load(rendered) || {})
   end
+
+  # On server startup, immediately enqueue a quest auto-start check so that
+  # the simulation resumes without waiting up to 60 s for the next cron tick.
+  config.on(:startup) do
+    QuestAutoStartWorker.perform_async
+  end
 end
 
 Sidekiq.configure_client do |config|

--- a/backend/config/sidekiq_cron.yml
+++ b/backend/config/sidekiq_cron.yml
@@ -18,3 +18,9 @@ eye_of_sauron:
   class: EyeOfSauronWorker
   queue: default
   description: "Sauron's Gaze — scans active regions every minute and creates threat events"
+
+quest_auto_start:
+  cron: "<%= ENV.fetch('QUEST_AUTO_START_CRON', '*/5 * * * *') %>"
+  class: QuestAutoStartWorker
+  queue: critical
+  description: "Safety-net: starts the next quest if no quest is active and the simulation is running"

--- a/backend/spec/jobs/quest_auto_start_worker_spec.rb
+++ b/backend/spec/jobs/quest_auto_start_worker_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuestAutoStartWorker, type: :job do
+  subject(:worker) { described_class.new }
+
+  let(:config) { SimulationConfig.current }
+
+  before do
+    SimulationConfig.destroy_all
+    config.update!(running: true)
+
+    # Release any lingering lock between examples.
+    Sidekiq.redis { |r| r.del(described_class::LOCK_KEY) }
+  end
+
+  # ── Basic guard conditions ──────────────────────────────────────────────────
+
+  describe "simulation not running" do
+    before { config.update!(running: false) }
+
+    it "does nothing" do
+      expect { worker.perform }.not_to change(QuestEvent, :count)
+    end
+
+    it "does not start any quest" do
+      worker.perform
+      expect(Quest.where(status: :active).count).to eq(0)
+    end
+  end
+
+  # ── Idempotency / duplicate-start guard ────────────────────────────────────
+
+  describe "idempotency in campaign mode" do
+    before { config.update!(mode: :campaign) }
+
+    it "does not start a second campaign quest when one is already active" do
+      create(:quest, quest_type: :campaign, status: :active, campaign_order: 1)
+      create(:quest, quest_type: :campaign, status: :pending, campaign_order: 2)
+
+      expect { worker.perform }.not_to change(Quest.where(status: :active), :count)
+    end
+  end
+
+  describe "idempotency in random mode" do
+    before { config.update!(mode: :random) }
+
+    it "does not start a second random quest when one is already active" do
+      create(:quest, quest_type: :random, status: :active)
+      create_list(:character, 3, status: :idle)
+
+      expect { worker.perform }.not_to change(Quest.where(quest_type: :random, status: :active), :count)
+    end
+  end
+
+  describe "Redis lock prevents concurrent starts" do
+    before { config.update!(mode: :campaign) }
+
+    it "returns without starting a quest when the lock is already held" do
+      create(:quest, quest_type: :campaign, status: :pending, campaign_order: 1)
+
+      # Simulate another worker instance already holding the lock.
+      Sidekiq.redis { |r| r.set(described_class::LOCK_KEY, 1, nx: true, ex: described_class::LOCK_TTL) }
+
+      expect { worker.perform }.not_to change(Quest.where(status: :active), :count)
+    end
+
+    it "releases the lock after a successful run" do
+      create(:quest, quest_type: :campaign, status: :pending, campaign_order: 1)
+      create_list(:character, 2, status: :idle)
+
+      worker.perform
+
+      held = Sidekiq.redis { |r| r.exists(described_class::LOCK_KEY) }
+      expect(held).to eq(0)
+    end
+  end
+
+  # ── Campaign mode ───────────────────────────────────────────────────────────
+
+  describe "campaign mode — auto-start" do
+    before { config.update!(mode: :campaign) }
+
+    let!(:quest1) do
+      create(:quest, quest_type: :campaign, campaign_order: 1, status: :pending, danger_level: 3)
+    end
+    let!(:quest2) do
+      create(:quest, quest_type: :campaign, campaign_order: 2, status: :pending, danger_level: 5)
+    end
+
+    it "activates the next pending campaign quest" do
+      worker.perform
+      expect(quest1.reload.status).to eq("active")
+    end
+
+    it "does not activate the second quest yet" do
+      worker.perform
+      expect(quest2.reload.status).to eq("pending")
+    end
+
+    it "assigns idle characters to the campaign quest" do
+      create_list(:character, 3, status: :idle)
+      worker.perform
+      expect(quest1.reload.quest_memberships.count).to be >= 1
+    end
+
+    it "sets assigned characters to on_quest" do
+      create_list(:character, 3, status: :idle)
+      worker.perform
+      quest1.reload.characters.each do |c|
+        expect(c.reload.status).to eq("on_quest")
+      end
+    end
+
+    it "creates a :started QuestEvent" do
+      worker.perform
+      event = QuestEvent.find_by(quest: quest1, event_type: :started)
+      expect(event).to be_present
+    end
+
+    it "updates campaign_position on the config" do
+      create_list(:character, 2, status: :idle)
+      worker.perform
+      expect(config.reload.campaign_position).to eq(1)
+    end
+
+    it "skips activation when no idle characters are available" do
+      # No characters — quest memberships stay empty, quest is still activated
+      # (the activation proceeds with an empty party; tested separately).
+      worker.perform
+      expect(quest1.reload.status).to eq("active")
+    end
+  end
+
+  describe "campaign mode — all quests completed, switches to random" do
+    before do
+      config.update!(mode: :campaign)
+      create(:quest, quest_type: :campaign, campaign_order: 1, status: :completed)
+    end
+
+    it "switches config to random mode" do
+      worker.perform
+      expect(config.reload.mode).to eq("random")
+    end
+
+    it "immediately starts a random quest when idle characters are available" do
+      create_list(:character, 3, status: :idle)
+
+      expect { worker.perform }.to change { Quest.where(quest_type: :random, status: :active).count }.by(1)
+    end
+
+    it "does not leave the simulation questless after campaign completion" do
+      create_list(:character, 3, status: :idle)
+      worker.perform
+      expect(Quest.where(status: :active).count).to eq(1)
+    end
+  end
+
+  # ── Random mode ─────────────────────────────────────────────────────────────
+
+  describe "random mode — auto-start" do
+    before do
+      config.update!(mode: :random)
+      Quest.where(quest_type: :campaign).destroy_all
+    end
+
+    it "generates a new random quest when none is active" do
+      create_list(:character, 3, status: :idle)
+      expect { worker.perform }.to change { Quest.where(quest_type: :random).count }.by(1)
+    end
+
+    it "activates the generated quest" do
+      create_list(:character, 3, status: :idle)
+      worker.perform
+      quest = Quest.where(quest_type: :random).last
+      expect(quest.status).to eq("active")
+    end
+
+    it "assigns 2-4 idle characters to the quest" do
+      create_list(:character, 4, status: :idle)
+      worker.perform
+      quest = Quest.where(quest_type: :random, status: :active).last
+      expect(quest.characters.count).to be_between(2, 4)
+    end
+
+    it "creates a :started QuestEvent for the random quest" do
+      create_list(:character, 3, status: :idle)
+      worker.perform
+      quest = Quest.where(quest_type: :random).last
+      event = QuestEvent.find_by(quest: quest, event_type: :started)
+      expect(event).to be_present
+    end
+
+    it "does not generate a quest when fewer than 2 idle characters exist" do
+      create(:character, status: :idle)
+      expect { worker.perform }.not_to change { Quest.where(quest_type: :random).count }
+    end
+  end
+
+  # ── Boot-time trigger: enqueued on Sidekiq startup ─────────────────────────
+
+  describe "enqueueing via perform_async (Sidekiq fake mode)" do
+    it "can be enqueued without error" do
+      expect { described_class.perform_async }.to change(described_class.jobs, :size).by(1)
+    end
+  end
+end

--- a/backend/spec/jobs/quest_tick_worker_spec.rb
+++ b/backend/spec/jobs/quest_tick_worker_spec.rb
@@ -330,4 +330,41 @@ RSpec.describe QuestTickWorker, type: :job do
       expect { worker.send(:broadcast_quest_update, quest, :completed) }.not_to raise_error
     end
   end
+
+  describe "quest success triggers QuestAutoStartWorker" do
+    let!(:quest) { create(:quest, :active, danger_level: 1, progress: 0.99) }
+    let!(:character) do
+      create(:character, status: :on_quest, strength: 20, wisdom: 20, endurance: 20, level: 1, xp: 0)
+    end
+
+    before do
+      create(:quest_membership, quest: quest, character: character)
+      config.update!(progress_min: 0.05, progress_max: 0.1)
+      allow_any_instance_of(QuestTickWorker).to receive(:rand).with(100.0).and_return(1.0)
+      allow_any_instance_of(QuestTickWorker).to receive(:rand).with(no_args).and_return(0.5)
+    end
+
+    it "enqueues QuestAutoStartWorker after a successful quest completion" do
+      expect { subject.perform }.to change(QuestAutoStartWorker.jobs, :size).by(1)
+    end
+  end
+
+  describe "campaign → random mode transition within the same tick" do
+    before do
+      config.update!(mode: :campaign)
+      # All campaign quests are already completed — advance_campaign will switch
+      # to random mode; ensure_random_quest should then run immediately.
+      create(:quest, quest_type: :campaign, campaign_order: 1, status: :completed)
+      create_list(:character, 3, status: :idle)
+    end
+
+    it "switches to random mode when all campaign quests are completed" do
+      subject.perform
+      expect(config.reload.mode).to eq("random")
+    end
+
+    it "starts a random quest in the same tick rather than waiting for the next cron run" do
+      expect { subject.perform }.to change { Quest.where(quest_type: :random, status: :active).count }.by(1)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Introduces `QuestAutoStartWorker` — a dedicated Sidekiq worker that immediately starts the next available quest without waiting for the next cron tick
- Fixes a latent bug in `QuestTickWorker#advance_campaign`: when all campaign quests complete and the mode switches to `:random`, the worker now calls `ensure_random_quest` in the same tick rather than leaving a 60-second gap
- Adds a Sidekiq startup hook so quest progression resumes the moment Sidekiq boots
- Guards against concurrent auto-start via a 30-second Redis `SET NX EX` lock

## Changes

### New: `app/jobs/quest_auto_start_worker.rb`
- Runs on the `:critical` queue; retries 3 times on error
- Fast-path: returns immediately if a quest is already active for the current mode (DB check before taking the lock)
- Acquires a short-lived distributed Redis lock to prevent duplicate starts under concurrent Sidekiq threads/processes
- Implements `advance_campaign` (campaign mode) and `ensure_random_quest` (random mode) — same logic as `QuestTickWorker` so the cron and the immediate trigger behave identically
- Triggered from three points (see below)

### Modified: `app/jobs/quest_tick_worker.rb`
- `handle_success` now enqueues `QuestAutoStartWorker.perform_async` after completing a quest, ensuring the next quest begins within seconds rather than waiting up to 60 s for the next cron tick
- `advance_campaign` now calls `ensure_random_quest` immediately after switching to `:random` mode, closing the previously open idle-period gap

### Modified: `config/initializers/sidekiq.rb`
- Adds `config.on(:startup) { QuestAutoStartWorker.perform_async }` inside `Sidekiq.configure_server` so the simulation resumes on every Sidekiq boot with no delay

### Modified: `config/sidekiq_cron.yml`
- Adds a `quest_auto_start` entry (default: every 5 minutes, overridable via `QUEST_AUTO_START_CRON`) as a belt-and-suspenders safety net

### New: `spec/jobs/quest_auto_start_worker_spec.rb`
- 22 examples covering all acceptance criteria: simulation guard, idempotency in both modes, Redis lock exclusion and release, campaign activation, campaign→random transition, random quest generation, and `perform_async` enqueueing

### Modified: `spec/jobs/quest_tick_worker_spec.rb`
- Adds tests verifying `QuestAutoStartWorker` is enqueued on quest success
- Adds tests verifying the campaign→random same-tick transition starts a random quest immediately

## Test results

```
73 examples, 0 failures
```
(22 quest_auto_start_worker_spec + 41 quest_tick_worker_spec + 10 sidekiq_cron_spec)

## Architectural note

`QuestAutoStartWorker` intentionally duplicates the campaign/random advancement logic from `QuestTickWorker` rather than extracting a shared service, keeping the blast radius of this bug-fix PR minimal. A follow-up refactor (e.g. a `QuestScheduler` service) can consolidate the two implementations in a feature sprint.

## Closes

Fixes #120

-- Devon (HiveLabs developer agent)