### PR TITLE
fix: assign characters and return members when starting a quest

### DIFF
--- a/backend/app/controllers/api/v1/quests_controller.rb
+++ b/backend/app/controllers/api/v1/quests_controller.rb
@@ -29,8 +29,10 @@ module Api
 
       # PATCH /api/v1/quests/:id
       def update
+        was_pending = @quest.pending?
         if @quest.update(quest_params)
-          render json: @quest
+          assign_idle_characters(@quest) if was_pending && @quest.active?
+          render json: quest_detail(@quest)
         else
           render json: { errors: @quest.errors.full_messages }, status: :unprocessable_entity
         end
@@ -101,6 +103,16 @@ module Api
           "members" => quest.characters.as_json(only: %i[id name race level status]),
           "success_chance" => quest.success_chance&.to_f
         )
+      end
+
+      def assign_idle_characters(quest)
+        idle_characters = Character.where(status: :idle).limit(4)
+        idle_characters.each do |character|
+          QuestMembership.find_or_create_by!(quest: quest, character: character) do |m|
+            m.role = "Adventurer"
+          end
+          character.update!(status: :on_quest)
+        end
       end
 
       def paginate(scope)

--- a/backend/spec/requests/api/v1/quests_spec.rb
+++ b/backend/spec/requests/api/v1/quests_spec.rb
@@ -115,6 +115,14 @@ RSpec.describe "Api::V1::Quests", type: :request do
       expect(quest.reload.title).to eq("New Title")
     end
 
+    it "returns members in the response" do
+      character = create(:character)
+      create(:quest_membership, quest: quest, character: character)
+      patch "/api/v1/quests/#{quest.id}", params: { quest: { title: "New Title" } }
+      expect(response.parsed_body["members"]).to be_an(Array)
+      expect(response.parsed_body["members"].first["id"]).to eq(character.id)
+    end
+
     it "returns 422 with invalid params" do
       patch "/api/v1/quests/#{quest.id}", params: { quest: { title: "" } }
       expect(response).to have_http_status(:unprocessable_entity)
@@ -123,6 +131,73 @@ RSpec.describe "Api::V1::Quests", type: :request do
     it "returns 404 for unknown quest" do
       patch "/api/v1/quests/0", params: { quest: { title: "X" } }
       expect(response).to have_http_status(:not_found)
+    end
+
+    context "when transitioning from pending to active (quest start)" do
+      let!(:idle_characters) { create_list(:character, 3, status: "idle") }
+
+      it "creates QuestMembership records for idle characters" do
+        expect {
+          patch "/api/v1/quests/#{quest.id}", params: { quest: { status: "active" } }
+        }.to change(QuestMembership, :count).by(3)
+      end
+
+      it "sets assigned characters to on_quest status" do
+        patch "/api/v1/quests/#{quest.id}", params: { quest: { status: "active" } }
+        assigned_ids = QuestMembership.where(quest: quest).pluck(:character_id)
+        expect(Character.where(id: assigned_ids).pluck(:status).uniq).to eq(["on_quest"])
+      end
+
+      it "returns the assigned members in the response" do
+        patch "/api/v1/quests/#{quest.id}", params: { quest: { status: "active" } }
+        expect(response.parsed_body["members"]).to be_an(Array)
+        expect(response.parsed_body["members"].length).to eq(3)
+      end
+
+      it "returns an empty members array when no idle characters are available" do
+        Character.update_all(status: "on_quest")
+        patch "/api/v1/quests/#{quest.id}", params: { quest: { status: "active" } }
+        expect(response.parsed_body["members"]).to eq([])
+      end
+
+      it "does not reassign characters that already have memberships" do
+        existing_char = idle_characters.first
+        create(:quest_membership, quest: quest, character: existing_char)
+
+        expect {
+          patch "/api/v1/quests/#{quest.id}", params: { quest: { status: "active" } }
+        }.to change(QuestMembership, :count).by(2)
+      end
+    end
+
+    context "when quest is already active" do
+      let!(:active_quest) { create(:quest, :active) }
+
+      it "does not auto-assign characters when updating a non-pending quest" do
+        create_list(:character, 3, status: "idle")
+        expect {
+          patch "/api/v1/quests/#{active_quest.id}", params: { quest: { title: "Updated" } }
+        }.not_to change(QuestMembership, :count)
+      end
+    end
+  end
+
+  describe "GET /api/v1/quests (index includes members)" do
+    let!(:quest) { create(:quest) }
+    let!(:character) { create(:character) }
+
+    before { create(:quest_membership, quest: quest, character: character) }
+
+    it "includes a members array for each quest" do
+      get "/api/v1/quests"
+      bodies = response.parsed_body
+      expect(bodies).to all(have_key("members"))
+    end
+
+    it "populates members with assigned characters" do
+      get "/api/v1/quests"
+      quest_body = response.parsed_body.find { |q| q["id"] == quest.id }
+      expect(quest_body["members"].first["id"]).to eq(character.id)
     end
   end
 

--- a/frontend/src/components/QuestDetailModal.test.tsx
+++ b/frontend/src/components/QuestDetailModal.test.tsx
@@ -96,4 +96,20 @@ describe('QuestDetailModal', () => {
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
+
+  it('shows empty state message when members array is present but empty', () => {
+    const noMembers: Quest = { ...sampleQuest, members: [] };
+    render(<QuestDetailModal quest={noMembers} onClose={vi.fn()} />, { wrapper });
+
+    expect(screen.getByTestId('no-members-message')).toBeInTheDocument();
+    expect(screen.getByText('No members assigned to this quest.')).toBeInTheDocument();
+  });
+
+  it('hides the members section when members is undefined', () => {
+    const noMembersField: Quest = { ...sampleQuest, members: undefined };
+    render(<QuestDetailModal quest={noMembersField} onClose={vi.fn()} />, { wrapper });
+
+    expect(screen.queryByTestId('no-members-message')).not.toBeInTheDocument();
+    expect(screen.queryByText('Members')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/QuestDetailModal.tsx
+++ b/frontend/src/components/QuestDetailModal.tsx
@@ -81,25 +81,31 @@ export function QuestDetailModal({ quest, onClose, onStart }: QuestDetailModalPr
           </Stack>
         )}
 
-        {quest.members && quest.members.length > 0 && (
+        {quest.members !== undefined && (
           <>
             <Divider />
             <Text fw={600} size="sm">
               Members
             </Text>
-            {quest.members.map((m) => (
-              <Group key={m.id} gap="xs">
-                <Text size="sm">{m.name}</Text>
-                <Badge size="xs" variant="outline" color="violet">
-                  {m.race}
-                </Badge>
-                {m.level != null && (
-                  <Badge size="xs" variant="outline" color="blue">
-                    Lvl {m.level}
+            {quest.members.length === 0 ? (
+              <Text size="sm" c="dimmed" data-testid="no-members-message">
+                No members assigned to this quest.
+              </Text>
+            ) : (
+              quest.members.map((m) => (
+                <Group key={m.id} gap="xs">
+                  <Text size="sm">{m.name}</Text>
+                  <Badge size="xs" variant="outline" color="violet">
+                    {m.race}
                   </Badge>
-                )}
-              </Group>
-            ))}
+                  {m.level != null && (
+                    <Badge size="xs" variant="outline" color="blue">
+                      Lvl {m.level}
+                    </Badge>
+                  )}
+                </Group>
+              ))
+            )}
           </>
         )}
 

--- a/frontend/src/routes/_auth/quests.tsx
+++ b/frontend/src/routes/_auth/quests.tsx
@@ -20,7 +20,7 @@ import { QuestDetailModal } from '../../components/QuestDetailModal';
 import { useQuestEventsChannel } from '../../hooks/useQuestEventsChannel';
 import { useQuests } from '../../hooks/useQuests';
 import { api } from '../../lib/api';
-import type { Quest } from '../../schemas/quest';
+import { type Quest, questSchema } from '../../schemas/quest';
 
 export const Route = createFileRoute('/_auth/quests')({
   component: QuestsPage,
@@ -117,13 +117,12 @@ export function QuestsPage() {
   const handleStartQuest = useCallback(async (questId: number) => {
     setStartError(null);
     try {
-      await api.patch(`/api/v1/quests/${questId}`, {
+      const response = await api.patch<unknown>(`/api/v1/quests/${questId}`, {
         quest: { status: 'active' },
       });
-      const apply = (q: Quest): Quest =>
-        q.id === questId ? { ...q, status: 'active' as const } : q;
-      setLiveQuests((prev) => prev.map(apply));
-      setSelectedQuest((prev) => (prev ? apply(prev) : null));
+      const updated = questSchema.parse(response.data);
+      setLiveQuests((prev) => prev.map((q) => (q.id === questId ? updated : q)));
+      setSelectedQuest(updated);
       notifications.show({
         title: 'Quest Started',
         message: 'Quest is now active',


### PR DESCRIPTION
## Summary

- **Backend**: `PATCH /api/v1/quests/:id` now auto-assigns up to 4 idle characters as `QuestMembership` records when a quest transitions `pending → active`, mirroring the existing `QuestAutoStartWorker` pattern
- **Backend**: `update` action returns `quest_detail` (with `members` array) instead of bare `@quest`
- **Frontend**: `handleStartQuest` parses the API response via `questSchema` and updates the quest in state with the full server payload (including members), replacing the optimistic status-only patch
- **Frontend**: `QuestDetailModal` now shows an empty-state message when `members` is a present but empty array (no idle characters available)

## Changes

| File | Change |
|------|--------|
| `backend/app/controllers/api/v1/quests_controller.rb` | `update` detects `pending→active` and calls `assign_idle_characters`; renders `quest_detail` |
| `backend/spec/requests/api/v1/quests_spec.rb` | New specs: auto-assign on start, character status, members in response, empty-member edge case, members in index |
| `frontend/src/routes/_auth/quests.tsx` | `handleStartQuest` uses `questSchema.parse(response.data)` to hydrate members |
| `frontend/src/components/QuestDetailModal.tsx` | Empty-state message when `members` is `[]` |
| `frontend/src/components/QuestDetailModal.test.tsx` | Two new tests: empty members state and undefined members |

## Story

Closes #123

## Testing Instructions

1. Reset all quests (`POST /api/v1/quests/reset?confirm=true`)
2. Open a pending quest in the modal — no members shown (field absent)
3. Click **Start Quest** — modal immediately shows assigned characters, quest is active
4. If no idle characters exist, modal shows "No members assigned to this quest."
5. `GET /api/v1/quests` — each quest object now includes a `members` array

## Notes

- `assign_idle_characters` uses `find_or_create_by!` to safely skip any character already assigned, preventing duplicate membership errors if the quest already had pre-assigned members
- Auto-assignment only triggers on `pending → active`; updating any other field on an active/completed quest does not re-trigger assignment

-- Devon (HiveLabs developer agent)