### PR TITLE
fix: SauronGazeChannel unsubscribe race condition

### DIFF
--- a/frontend/src/hooks/useSauronGazeChannel.test.tsx
+++ b/frontend/src/hooks/useSauronGazeChannel.test.tsx
@@ -78,9 +78,26 @@ describe('useSauronGazeChannel', () => {
     expect(result.current.connectionStatus).toBe('disconnected');
   });
 
-  it('unsubscribes on unmount', () => {
+  it('unsubscribes on unmount after subscription is confirmed', () => {
+    const { unmount } = renderHook(() => useSauronGazeChannel(), { wrapper });
+    act(() => capturedCallbacks.connected?.());
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('does not call unsubscribe immediately if component unmounts before confirmation (race condition)', () => {
+    const { unmount } = renderHook(() => useSauronGazeChannel(), { wrapper });
+    // Unmount before connected() fires — must NOT send unsubscribe yet
+    unmount();
+    expect(mockUnsubscribe).not.toHaveBeenCalled();
+  });
+
+  it('issues a deferred unsubscribe when connected() fires after component has unmounted', () => {
     const { unmount } = renderHook(() => useSauronGazeChannel(), { wrapper });
     unmount();
+    expect(mockUnsubscribe).not.toHaveBeenCalled();
+    // Server confirms subscription after unmount — deferred cleanup fires
+    act(() => capturedCallbacks.connected?.());
     expect(mockUnsubscribe).toHaveBeenCalledOnce();
   });
 
@@ -91,6 +108,7 @@ describe('useSauronGazeChannel', () => {
       );
     });
     const { unmount } = renderHook(() => useSauronGazeChannel(), { wrapper });
+    act(() => capturedCallbacks.connected?.());
     expect(() => unmount()).not.toThrow();
   });
 });

--- a/frontend/src/hooks/useSauronGazeChannel.ts
+++ b/frontend/src/hooks/useSauronGazeChannel.ts
@@ -24,13 +24,34 @@ export function useSauronGazeChannel(): UseSauronGazeChannelResult {
   const subscriptionRef = useRef<ReturnType<typeof consumer.subscriptions.create> | null>(null);
 
   useEffect(() => {
+    // Track whether the server has confirmed this subscription.
+    // ActionCable raises RuntimeError if `unsubscribe` is called before
+    // confirmation arrives, so we only call it once `connected()` has fired.
+    let isConnected = false;
+    // Track whether the component unmounted before confirmation so we can
+    // issue a deferred unsubscribe from inside the connected() callback.
+    let unmounted = false;
+
     subscriptionRef.current = consumer.subscriptions.create(
       { channel: 'SauronGazeChannel' },
       {
         connected() {
+          isConnected = true;
+          if (unmounted) {
+            // Component unmounted while confirmation was in flight.
+            // Issue the deferred unsubscribe now that the server has confirmed.
+            try {
+              subscriptionRef.current?.unsubscribe();
+            } catch {
+              // already removed
+            }
+            subscriptionRef.current = null;
+            return;
+          }
           setConnectionStatus('connected');
         },
         disconnected() {
+          isConnected = false;
           setConnectionStatus('disconnected');
         },
         rejected() {
@@ -43,13 +64,20 @@ export function useSauronGazeChannel(): UseSauronGazeChannelResult {
     );
 
     return () => {
-      try {
-        subscriptionRef.current?.unsubscribe();
-      } catch {
-        // Subscription may already be removed if the consumer was disconnected
-        // (e.g. token refresh) before this cleanup ran.
+      unmounted = true;
+      if (isConnected) {
+        // Subscription is confirmed — safe to unsubscribe immediately.
+        try {
+          subscriptionRef.current?.unsubscribe();
+        } catch {
+          // Subscription may already be removed if the consumer was disconnected
+          // (e.g. token refresh) before this cleanup ran.
+        }
+        subscriptionRef.current = null;
       }
-      subscriptionRef.current = null;
+      // If !isConnected: connected() hasn't fired yet.
+      // Setting unmounted=true above causes the connected() callback to issue
+      // the deferred unsubscribe once the server confirms the subscription.
     };
   }, [consumer]);
 


### PR DESCRIPTION
## Summary

- Fixes the `RuntimeError - Unable to find subscription` that appears in backend logs when `SauronGazeChannel` unsubscribes before the server has confirmed the subscription
- Guards `unsubscribe()` behind a confirmed-connection flag so it is only called after `connected()` has fired
- Handles the deferred-unsubscribe path: if the component unmounts while confirmation is still in flight, the `connected()` callback itself issues the unsubscribe once the server confirms

## Root Cause

React (especially in Strict Mode or during fast route transitions) can unmount a component before the ActionCable subscription confirmation (`connected()`) arrives. Calling `subscription.unsubscribe()` at that point sends an unsubscribe command while the server is still processing the subscribe — resulting in:

```
RuntimeError - Unable to find subscription with identifier: {"channel":"SauronGazeChannel"}
```

The pre-existing `try/catch` silenced the client-side exception but did **not** prevent the server-side `RuntimeError`.

## Changes

**`frontend/src/hooks/useSauronGazeChannel.ts`**
- Added two local closure variables inside `useEffect`: `isConnected` and `unmounted`
- `connected()` sets `isConnected = true`; if `unmounted` is already `true`, issues the deferred `unsubscribe()` and returns early
- `disconnected()` resets `isConnected = false`
- Cleanup function sets `unmounted = true` and only calls `unsubscribe()` when `isConnected` is `true` (i.e. the server already confirmed the subscription)

**`frontend/src/hooks/useSauronGazeChannel.test.tsx`**
- Updated `unsubscribes on unmount` test to call `connected()` before unmounting (required by new guard)
- Added test: `does not call unsubscribe immediately if component unmounts before confirmation`
- Added test: `issues a deferred unsubscribe when connected() fires after component has unmounted`
- Updated error-resilience test to confirm connection before triggering the failing unsubscribe

## Testing

All existing tests updated; two new regression tests cover both sides of the race condition.

## Story

Closes #125

-- Devon (HiveLabs developer agent)