### PR TITLE
fix: zero out character level/xp on quest reset (#122)

### DIFF
--- a/backend/app/controllers/api/v1/quests_controller.rb
+++ b/backend/app/controllers/api/v1/quests_controller.rb
@@ -54,7 +54,7 @@ module Api
         Quest.transaction do
           QuestMembership.delete_all
           Quest.update_all(status: "pending", progress: 0.0, attempts: 0)
-          Character.update_all(status: "idle")
+          Character.update_all(status: "idle", level: 0, xp: 0)
         end
 
         render json: { message: "All quests reset to pending state", count: Quest.count }

--- a/backend/spec/requests/api/v1/quests_spec.rb
+++ b/backend/spec/requests/api/v1/quests_spec.rb
@@ -311,34 +311,34 @@ RSpec.describe "Api::V1::Quests", type: :request do
         expect(Character.all.pluck(:status).uniq).to eq(["idle"])
       end
 
-      it "preserves character level and xp across quest reset" do
+      it "zeroes out character level and xp on quest reset" do
         leveled_char = create(:character, level: 5, xp: 2000, status: "on_quest")
         post "/api/v1/quests/reset", params: { confirm: true }
         leveled_char.reload
-        expect(leveled_char.level).to eq(5)
-        expect(leveled_char.xp).to eq(2000)
+        expect(leveled_char.level).to eq(0)
+        expect(leveled_char.xp).to eq(0)
       end
 
-      it "preserves level and xp for multiple characters with different stats" do
+      it "zeroes out level and xp for multiple characters with different stats" do
         char_a = create(:character, level: 3, xp: 1000, status: "on_quest")
         char_b = create(:character, level: 7, xp: 5000, status: "idle")
         post "/api/v1/quests/reset", params: { confirm: true }
-        expect(char_a.reload.level).to eq(3)
-        expect(char_a.reload.xp).to eq(1000)
-        expect(char_b.reload.level).to eq(7)
-        expect(char_b.reload.xp).to eq(5000)
+        expect(char_a.reload.level).to eq(0)
+        expect(char_a.reload.xp).to eq(0)
+        expect(char_b.reload.level).to eq(0)
+        expect(char_b.reload.xp).to eq(0)
       end
 
-      it "returns correct non-zeroed level for a character via the API after reset" do
+      it "returns zeroed level and xp for a character via the API after reset" do
         leveled_char = create(:character, level: 5, xp: 2000, status: "on_quest")
         post "/api/v1/quests/reset", params: { confirm: true }
         get "/api/v1/characters/#{leveled_char.id}"
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body["level"]).to eq(5)
-        expect(response.parsed_body["xp"]).to eq(2000)
+        expect(response.parsed_body["level"]).to eq(0)
+        expect(response.parsed_body["xp"]).to eq(0)
       end
 
-      it "returns correct level for fellowship members after reset and re-assignment" do
+      it "returns zeroed level for fellowship members after reset and re-assignment" do
         leveled_char = create(:character, level: 5, xp: 2000, status: "idle")
         quest = create(:quest)
         post "/api/v1/quests/reset", params: { confirm: true }
@@ -348,7 +348,7 @@ RSpec.describe "Api::V1::Quests", type: :request do
         get "/api/v1/quests/#{quest.id}"
         member = response.parsed_body["members"].find { |m| m["id"] == leveled_char.id }
         expect(member).not_to be_nil
-        expect(member["level"]).to eq(5)
+        expect(member["level"]).to eq(0)
       end
     end
   end


### PR DESCRIPTION
## Summary

Addresses the reviewer's requested changes from PR #132 — the corrected Issue #122 spec requires quest reset to **wipe character level and xp to zero**, not preserve them.

### Changes (surgical, two files only)

1. **Reset action** (`quests_controller.rb` L57): `Character.update_all(status: 'idle')` → `Character.update_all(status: 'idle', level: 0, xp: 0)`

2. **4 regression tests rewritten** (`quests_spec.rb`): All four tests now assert `level == 0` and `xp == 0` after reset (previously asserted preservation). Test names updated to reflect the correct behavior:
   - `"zeroes out character level and xp on quest reset"` — DB-level single character
   - `"zeroes out level and xp for multiple characters with different stats"` — DB-level multi-character
   - `"returns zeroed level and xp for a character via the API after reset"` — API-level via GET /characters/:id
   - `"returns zeroed level for fellowship members after reset and re-assignment"` — quest detail members endpoint

### What's preserved from PR #132 (all approved by reviewer)

- ✅ `progress.to_f` serialisation fix in `quest_detail`
- ✅ `assign_idle_characters` auto-assignment logic
- ✅ `SauronGaze` race condition fix (deferred unsubscribe)
- ✅ `QuestDetailModal` empty-members handling
- ✅ README addition

### Context

- Replaces closed PR #132 (REQUEST_CHANGES — spec was corrected post-submission)
- Review: https://github.com/AshDevFr/experiment-RFHBX/pull/132#pullrequestreview-4002007610

Closes #122

-- Sean (HiveLabs senior developer agent)