### PR TITLE
fix: Fellowship UI shows raw status instead of human-readable badge labels

### DIFF
--- a/frontend/src/components/CharacterCard.test.tsx
+++ b/frontend/src/components/CharacterCard.test.tsx
@@ -58,10 +58,31 @@ describe('CharacterCard', () => {
     expect(screen.queryByText(/^Lv\./)).not.toBeInTheDocument();
   });
 
-  it('renders the status badge', () => {
+  it('renders the status badge with human-readable label for idle', () => {
     render(<CharacterCard character={sampleCharacter} onClick={vi.fn()} />, { wrapper });
 
-    expect(screen.getByText('idle')).toBeInTheDocument();
+    expect(screen.getByText('IDLE')).toBeInTheDocument();
+  });
+
+  it('renders ON QUEST badge for on_quest status', () => {
+    const onQuestChar: Character = { ...sampleCharacter, status: 'on_quest' };
+    render(<CharacterCard character={onQuestChar} onClick={vi.fn()} />, { wrapper });
+
+    expect(screen.getByText('ON QUEST')).toBeInTheDocument();
+  });
+
+  it('renders FALLEN badge for fallen status', () => {
+    const fallenChar: Character = { ...sampleCharacter, status: 'fallen' };
+    render(<CharacterCard character={fallenChar} onClick={vi.fn()} />, { wrapper });
+
+    expect(screen.getByText('FALLEN')).toBeInTheDocument();
+  });
+
+  it('does not render a status badge when status is absent', () => {
+    const noStatus: Character = { id: 5, name: 'Unknown Wanderer', race: 'Man' };
+    render(<CharacterCard character={noStatus} onClick={vi.fn()} />, { wrapper });
+
+    expect(screen.queryByText('IDLE')).not.toBeInTheDocument();
   });
 
   it('calls onClick with the character when clicked', async () => {

--- a/frontend/src/components/CharacterCard.tsx
+++ b/frontend/src/components/CharacterCard.tsx
@@ -6,16 +6,23 @@ interface CharacterCardProps {
   onClick: (character: Character) => void;
 }
 
-const STATUS_COLORS: Record<string, string> = {
+export const STATUS_COLORS: Record<string, string> = {
   idle: 'gray',
-  active: 'green',
   on_quest: 'blue',
-  injured: 'orange',
-  dead: 'red',
+  fallen: 'red',
+};
+
+export const STATUS_LABELS: Record<string, string> = {
+  idle: 'IDLE',
+  on_quest: 'ON QUEST',
+  fallen: 'FALLEN',
 };
 
 export function CharacterCard({ character, onClick }: CharacterCardProps) {
   const statusColor = STATUS_COLORS[character.status ?? 'idle'] ?? 'gray';
+  const statusLabel = character.status
+    ? (STATUS_LABELS[character.status] ?? character.status.toUpperCase())
+    : undefined;
 
   return (
     <Card
@@ -32,9 +39,9 @@ export function CharacterCard({ character, onClick }: CharacterCardProps) {
           <Text fw={700} size="md" style={{ flex: 1 }}>
             {character.name}
           </Text>
-          {character.status && (
+          {statusLabel && (
             <Badge color={statusColor} size="sm" variant="light">
-              {character.status}
+              {statusLabel}
             </Badge>
           )}
         </Group>

--- a/frontend/src/components/CharacterDetailModal.tsx
+++ b/frontend/src/components/CharacterDetailModal.tsx
@@ -1,5 +1,6 @@
 import { Badge, Divider, Group, Modal, SimpleGrid, Stack, Text } from '@mantine/core';
 import type { Character } from '../schemas/character';
+import { STATUS_COLORS, STATUS_LABELS } from './CharacterCard';
 
 interface CharacterDetailModalProps {
   character: Character | null;
@@ -51,8 +52,8 @@ export function CharacterDetailModal({ character, onClose }: CharacterDetailModa
             </Badge>
           )}
           {character.status && (
-            <Badge variant="light" color="gray">
-              {character.status}
+            <Badge variant="light" color={STATUS_COLORS[character.status] ?? 'gray'}>
+              {STATUS_LABELS[character.status] ?? character.status.toUpperCase()}
             </Badge>
           )}
           {character.ring_bearer && (


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `CharacterCard` now maps raw API status values to human-readable badge labels: `on_quest` → `ON QUEST`, `idle` → `IDLE`, `fallen` → `FALLEN`
- `STATUS_COLORS` and `STATUS_LABELS` constants exported from `CharacterCard` and reused in `CharacterDetailModal`, which also gains correct per-status badge colours (`blue` for on_quest, `red` for fallen, `gray` for idle)
- Vitest coverage added for all three status variants (`idle`, `on_quest`, `fallen`) and the no-status case

## Changes

- `frontend/src/components/CharacterCard.tsx` — export `STATUS_COLORS`/`STATUS_LABELS`, compute `statusLabel` and render it in the badge
- `frontend/src/components/CharacterDetailModal.tsx` — import shared constants, use correct label and colour in the status badge
- `frontend/src/components/CharacterCard.test.tsx` — update existing idle test to assert `IDLE`; add three new tests for `on_quest`, `fallen`, and absent status

## Root cause

The badge was rendering `{character.status}` (raw snake_case from the API) instead of a formatted label. The backend `GET /api/v1/characters` already returns `status` in the serialized response (confirmed via `Character#as_json` which includes all DB columns), so **this is a purely frontend fix**.

## Story

Closes #152

## Testing

1. `npm run test` — 159 tests pass (22 test files)
2. `npm run lint` — exit 0, no new errors
3. `npm run build` — clean build

-- Devon (HiveLabs developer agent)
EOF
)