### PR TITLE
feat: chaos injection endpoints for disaster recovery training

### DIFF
--- a/backend/app/controllers/api/v1/chaos_controller.rb
+++ b/backend/app/controllers/api/v1/chaos_controller.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ChaosController < ApplicationController
+      # POST /api/v1/chaos/kill_character
+      # Kills a random non-fallen character for disaster recovery training.
+      def kill_character
+        character = Character.where.not(status: :fallen).order(Arel.sql("RANDOM()")).first
+
+        unless character
+          return render json: { error: "No eligible characters to kill" },
+                        status: :unprocessable_entity
+        end
+
+        character.update!(status: :fallen)
+
+        render json: {
+          affected: {
+            id: character.id,
+            name: character.name,
+            status: character.status
+          }
+        }
+      end
+
+      # POST /api/v1/chaos/fail_quest
+      # Fails a random active quest and returns its members to idle.
+      def fail_quest
+        quest = Quest.where(status: :active).order(Arel.sql("RANDOM()")).first
+
+        unless quest
+          return render json: { error: "No active quests to fail" },
+                        status: :unprocessable_entity
+        end
+
+        ActiveRecord::Base.transaction do
+          quest.update!(status: :failed)
+          quest.characters.where.not(status: :fallen).update_all(status: "idle")
+        end
+
+        render json: {
+          affected: {
+            id: quest.id,
+            title: quest.title,
+            status: quest.status
+          }
+        }
+      end
+
+      # POST /api/v1/chaos/destroy_artifact
+      # Destroys a random artifact permanently.
+      def destroy_artifact
+        artifact = Artifact.order(Arel.sql("RANDOM()")).first
+
+        unless artifact
+          return render json: { error: "No artifacts to destroy" },
+                        status: :unprocessable_entity
+        end
+
+        affected = { id: artifact.id, name: artifact.name, artifact_type: artifact.artifact_type }
+        artifact.destroy!
+
+        render json: { affected: affected }
+      end
+
+      # POST /api/v1/chaos/drain_xp
+      # Drains 50% XP from all non-fallen characters (floor to 0).
+      def drain_xp
+        characters = Character.where.not(status: :fallen)
+
+        if characters.none?
+          return render json: { error: "No characters to drain" },
+                        status: :unprocessable_entity
+        end
+
+        total_drained = 0
+
+        ActiveRecord::Base.transaction do
+          characters.each do |character|
+            amount = (character.xp * 0.5).floor
+            total_drained += amount
+            character.update!(xp: character.xp - amount)
+          end
+        end
+
+        render json: {
+          characters_affected: characters.count,
+          xp_drained: total_drained
+        }
+      end
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -65,6 +65,11 @@ Rails.application.routes.draw do
       patch "simulation/config", to: "simulation#update_config"
       post  "simulation/reset",  to: "simulation#reset"
 
+      post "chaos/kill_character",   to: "chaos#kill_character"
+      post "chaos/fail_quest",       to: "chaos#fail_quest"
+      post "chaos/destroy_artifact", to: "chaos#destroy_artifact"
+      post "chaos/drain_xp",         to: "chaos#drain_xp"
+
       resources :events, only: %i[index]
       get "leaderboard", to: "leaderboard#index"
       post "palantir/send", to: "palantir#deliver"

--- a/backend/spec/integration/chaos_spec.rb
+++ b/backend/spec/integration/chaos_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Chaos", type: :request do
+  path "/api/v1/chaos/kill_character" do
+    post "Kill a random character" do
+      tags "Chaos"
+      operationId "chaosKillCharacter"
+      produces "application/json"
+      description "Kills a random non-fallen character for disaster recovery training. " \
+                  "Returns 422 if no eligible characters exist."
+
+      response "200", "character killed" do
+        schema "$ref" => "#/components/schemas/ChaosKillResult"
+        before { create(:character, status: :idle) }
+        run_test!
+      end
+
+      response "422", "no eligible characters" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/chaos/fail_quest" do
+    post "Fail a random active quest" do
+      tags "Chaos"
+      operationId "chaosFailQuest"
+      produces "application/json"
+      description "Fails a random active quest and returns its non-fallen members to idle. " \
+                  "Returns 422 if no active quests exist."
+
+      response "200", "quest failed" do
+        schema "$ref" => "#/components/schemas/ChaosFailQuestResult"
+        before do
+          character = create(:character, status: :on_quest)
+          quest = create(:quest, status: :active)
+          create(:quest_membership, quest: quest, character: character)
+        end
+        run_test!
+      end
+
+      response "422", "no active quests" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/chaos/destroy_artifact" do
+    post "Destroy a random artifact" do
+      tags "Chaos"
+      operationId "chaosDestroyArtifact"
+      produces "application/json"
+      description "Permanently destroys a random artifact. " \
+                  "Returns 422 if no artifacts exist."
+
+      response "200", "artifact destroyed" do
+        schema "$ref" => "#/components/schemas/ChaosDestroyArtifactResult"
+        before { create(:artifact) }
+        run_test!
+      end
+
+      response "422", "no artifacts" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/chaos/drain_xp" do
+    post "Drain XP from all characters" do
+      tags "Chaos"
+      operationId "chaosDrainXp"
+      produces "application/json"
+      description "Drains 50% XP from all non-fallen characters. " \
+                  "Returns 422 if no eligible characters exist."
+
+      response "200", "XP drained" do
+        schema "$ref" => "#/components/schemas/ChaosDrainXpResult"
+        before { create(:character, status: :idle, xp: 1000) }
+        run_test!
+      end
+
+      response "422", "no eligible characters" do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/chaos_spec.rb
+++ b/backend/spec/requests/api/v1/chaos_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Chaos", type: :request do
+  # ---------------------------------------------------------------------------
+  # POST /api/v1/chaos/kill_character
+  # ---------------------------------------------------------------------------
+  describe "POST /api/v1/chaos/kill_character" do
+    context "when eligible characters exist" do
+      let!(:character) { create(:character, status: :idle) }
+
+      it "returns HTTP 200" do
+        post "/api/v1/chaos/kill_character"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "sets the character status to fallen" do
+        post "/api/v1/chaos/kill_character"
+        expect(character.reload.status).to eq("fallen")
+      end
+
+      it "returns the affected character details" do
+        post "/api/v1/chaos/kill_character"
+        body = response.parsed_body
+        expect(body["affected"]).to include("id", "name", "status")
+        expect(body["affected"]["status"]).to eq("fallen")
+      end
+    end
+
+    context "when an on_quest character exists" do
+      let!(:character) { create(:character, status: :on_quest) }
+
+      it "is eligible for killing" do
+        post "/api/v1/chaos/kill_character"
+        expect(character.reload.status).to eq("fallen")
+      end
+    end
+
+    context "when all characters are already fallen" do
+      let!(:character) { create(:character, status: :fallen) }
+
+      it "returns HTTP 422" do
+        post "/api/v1/chaos/kill_character"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "returns an error message" do
+        post "/api/v1/chaos/kill_character"
+        expect(response.parsed_body["error"]).to be_present
+      end
+    end
+
+    context "when no characters exist" do
+      it "returns HTTP 422" do
+        post "/api/v1/chaos/kill_character"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /api/v1/chaos/fail_quest
+  # ---------------------------------------------------------------------------
+  describe "POST /api/v1/chaos/fail_quest" do
+    context "when an active quest exists" do
+      let!(:character) { create(:character, status: :on_quest) }
+      let!(:quest) do
+        q = create(:quest, status: :active)
+        create(:quest_membership, quest: q, character: character)
+        q
+      end
+
+      it "returns HTTP 200" do
+        post "/api/v1/chaos/fail_quest"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "sets the quest status to failed" do
+        post "/api/v1/chaos/fail_quest"
+        expect(quest.reload.status).to eq("failed")
+      end
+
+      it "returns the affected quest details" do
+        post "/api/v1/chaos/fail_quest"
+        body = response.parsed_body
+        expect(body["affected"]).to include("id", "title", "status")
+        expect(body["affected"]["status"]).to eq("failed")
+      end
+
+      it "returns non-fallen members to idle" do
+        post "/api/v1/chaos/fail_quest"
+        expect(character.reload.status).to eq("idle")
+      end
+    end
+
+    context "when no active quests exist" do
+      let!(:quest) { create(:quest, status: :pending) }
+
+      it "returns HTTP 422" do
+        post "/api/v1/chaos/fail_quest"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "returns an error message" do
+        post "/api/v1/chaos/fail_quest"
+        expect(response.parsed_body["error"]).to be_present
+      end
+    end
+
+    context "when fallen members are on the quest" do
+      let!(:fallen_character) { create(:character, status: :fallen) }
+      let!(:quest) do
+        q = create(:quest, status: :active)
+        create(:quest_membership, quest: q, character: fallen_character)
+        q
+      end
+
+      it "does not change fallen character status" do
+        post "/api/v1/chaos/fail_quest"
+        expect(fallen_character.reload.status).to eq("fallen")
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /api/v1/chaos/destroy_artifact
+  # ---------------------------------------------------------------------------
+  describe "POST /api/v1/chaos/destroy_artifact" do
+    context "when artifacts exist" do
+      let!(:artifact) { create(:artifact) }
+
+      it "returns HTTP 200" do
+        post "/api/v1/chaos/destroy_artifact"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "destroys one artifact" do
+        expect { post "/api/v1/chaos/destroy_artifact" }
+          .to change(Artifact, :count).by(-1)
+      end
+
+      it "returns the affected artifact details" do
+        post "/api/v1/chaos/destroy_artifact"
+        body = response.parsed_body
+        expect(body["affected"]).to include("id", "name", "artifact_type")
+      end
+    end
+
+    context "when no artifacts exist" do
+      it "returns HTTP 422" do
+        post "/api/v1/chaos/destroy_artifact"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "returns an error message" do
+        post "/api/v1/chaos/destroy_artifact"
+        expect(response.parsed_body["error"]).to be_present
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /api/v1/chaos/drain_xp
+  # ---------------------------------------------------------------------------
+  describe "POST /api/v1/chaos/drain_xp" do
+    context "when non-fallen characters exist" do
+      let!(:char1) { create(:character, status: :idle, xp: 1000) }
+      let!(:char2) { create(:character, status: :on_quest, xp: 2000) }
+
+      it "returns HTTP 200" do
+        post "/api/v1/chaos/drain_xp"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "drains 50% XP from each character" do
+        post "/api/v1/chaos/drain_xp"
+        expect(char1.reload.xp).to eq(500)
+        expect(char2.reload.xp).to eq(1000)
+      end
+
+      it "returns characters_affected count" do
+        post "/api/v1/chaos/drain_xp"
+        expect(response.parsed_body["characters_affected"]).to eq(2)
+      end
+
+      it "returns total xp_drained" do
+        post "/api/v1/chaos/drain_xp"
+        expect(response.parsed_body["xp_drained"]).to eq(1500)
+      end
+    end
+
+    context "when a character has zero XP" do
+      let!(:char) { create(:character, status: :idle, xp: 0) }
+
+      it "returns HTTP 200 without error" do
+        post "/api/v1/chaos/drain_xp"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not reduce XP below zero" do
+        post "/api/v1/chaos/drain_xp"
+        expect(char.reload.xp).to eq(0)
+      end
+    end
+
+    context "when only fallen characters exist" do
+      let!(:char) { create(:character, status: :fallen, xp: 1000) }
+
+      it "returns HTTP 422" do
+        post "/api/v1/chaos/drain_xp"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "returns an error message" do
+        post "/api/v1/chaos/drain_xp"
+        expect(response.parsed_body["error"]).to be_present
+      end
+
+      it "does not drain fallen character XP" do
+        post "/api/v1/chaos/drain_xp"
+        expect(char.reload.xp).to eq(1000)
+      end
+    end
+
+    context "when no characters exist" do
+      it "returns HTTP 422" do
+        post "/api/v1/chaos/drain_xp"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -377,6 +377,78 @@ RSpec.configure do |config|
               }
             },
             required: %w[errors]
+          },
+
+          ChaosKillResult: {
+            type: :object,
+            description: "Result of a kill_character chaos injection",
+            properties: {
+              affected: {
+                type: :object,
+                description: "The character that was killed",
+                properties: {
+                  id: { type: :integer, example: 1 },
+                  name: { type: :string, example: "Boromir" },
+                  status: { type: :string, example: "fallen" }
+                },
+                required: %w[id name status]
+              }
+            },
+            required: %w[affected]
+          },
+
+          ChaosFailQuestResult: {
+            type: :object,
+            description: "Result of a fail_quest chaos injection",
+            properties: {
+              affected: {
+                type: :object,
+                description: "The quest that was failed",
+                properties: {
+                  id: { type: :integer, example: 1 },
+                  title: { type: :string, example: "Destroy the One Ring" },
+                  status: { type: :string, example: "failed" }
+                },
+                required: %w[id title status]
+              }
+            },
+            required: %w[affected]
+          },
+
+          ChaosDestroyArtifactResult: {
+            type: :object,
+            description: "Result of a destroy_artifact chaos injection",
+            properties: {
+              affected: {
+                type: :object,
+                description: "The artifact that was destroyed",
+                properties: {
+                  id: { type: :integer, example: 1 },
+                  name: { type: :string, example: "The One Ring" },
+                  artifact_type: { type: :string, example: "ring" }
+                },
+                required: %w[id name artifact_type]
+              }
+            },
+            required: %w[affected]
+          },
+
+          ChaosDrainXpResult: {
+            type: :object,
+            description: "Result of a drain_xp chaos injection",
+            properties: {
+              characters_affected: {
+                type: :integer,
+                description: "Number of characters whose XP was drained",
+                example: 5
+              },
+              xp_drained: {
+                type: :integer,
+                description: "Total XP drained across all affected characters",
+                example: 2500
+              }
+            },
+            required: %w[characters_affected xp_drained]
           }
         }
       }

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -615,6 +615,90 @@ components:
           - Level must be greater than 0
       required:
       - errors
+    ChaosKillResult:
+      type: object
+      description: Result of a kill_character chaos injection
+      properties:
+        affected:
+          type: object
+          description: The character that was killed
+          properties:
+            id:
+              type: integer
+              example: 1
+            name:
+              type: string
+              example: Boromir
+            status:
+              type: string
+              example: fallen
+          required:
+          - id
+          - name
+          - status
+      required:
+      - affected
+    ChaosFailQuestResult:
+      type: object
+      description: Result of a fail_quest chaos injection
+      properties:
+        affected:
+          type: object
+          description: The quest that was failed
+          properties:
+            id:
+              type: integer
+              example: 1
+            title:
+              type: string
+              example: Destroy the One Ring
+            status:
+              type: string
+              example: failed
+          required:
+          - id
+          - title
+          - status
+      required:
+      - affected
+    ChaosDestroyArtifactResult:
+      type: object
+      description: Result of a destroy_artifact chaos injection
+      properties:
+        affected:
+          type: object
+          description: The artifact that was destroyed
+          properties:
+            id:
+              type: integer
+              example: 1
+            name:
+              type: string
+              example: The One Ring
+            artifact_type:
+              type: string
+              example: ring
+          required:
+          - id
+          - name
+          - artifact_type
+      required:
+      - affected
+    ChaosDrainXpResult:
+      type: object
+      description: Result of a drain_xp chaos injection
+      properties:
+        characters_affected:
+          type: integer
+          description: Number of characters whose XP was drained
+          example: 5
+        xp_drained:
+          type: integer
+          description: Total XP drained across all affected characters
+          example: 2500
+      required:
+      - characters_affected
+      - xp_drained
 paths:
   "/api/v1/artifacts":
     get:
@@ -752,6 +836,90 @@ paths:
                 artifact:
                   "$ref": "#/components/schemas/ArtifactInput"
         required: true
+  "/api/v1/chaos/kill_character":
+    post:
+      summary: Kill a random character
+      tags:
+      - Chaos
+      operationId: chaosKillCharacter
+      description: Kills a random non-fallen character for disaster recovery training.
+        Returns 422 if no eligible characters exist.
+      responses:
+        '200':
+          description: character killed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ChaosKillResult"
+        '422':
+          description: no eligible characters
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/chaos/fail_quest":
+    post:
+      summary: Fail a random active quest
+      tags:
+      - Chaos
+      operationId: chaosFailQuest
+      description: Fails a random active quest and returns its non-fallen members
+        to idle. Returns 422 if no active quests exist.
+      responses:
+        '200':
+          description: quest failed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ChaosFailQuestResult"
+        '422':
+          description: no active quests
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/chaos/destroy_artifact":
+    post:
+      summary: Destroy a random artifact
+      tags:
+      - Chaos
+      operationId: chaosDestroyArtifact
+      description: Permanently destroys a random artifact. Returns 422 if no artifacts
+        exist.
+      responses:
+        '200':
+          description: artifact destroyed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ChaosDestroyArtifactResult"
+        '422':
+          description: no artifacts
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/chaos/drain_xp":
+    post:
+      summary: Drain XP from all characters
+      tags:
+      - Chaos
+      operationId: chaosDrainXp
+      description: Drains 50% XP from all non-fallen characters. Returns 422 if no
+        eligible characters exist.
+      responses:
+        '200':
+          description: XP drained
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ChaosDrainXpResult"
+        '422':
+          description: no eligible characters
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v1/characters":
     get:
       summary: List all characters

--- a/frontend/src/hooks/useChaos.ts
+++ b/frontend/src/hooks/useChaos.ts
@@ -1,0 +1,102 @@
+import { useCallback, useState } from 'react';
+import { api } from '../lib/api';
+import {
+  type ChaosActionResult,
+  type ChaosDestroyArtifactResult,
+  type ChaosDrainXpResult,
+  type ChaosFailQuestResult,
+  type ChaosKillResult,
+  chaosDestroyArtifactResultSchema,
+  chaosDrainXpResultSchema,
+  chaosFailQuestResultSchema,
+  chaosKillResultSchema,
+} from '../schemas/chaos';
+
+export interface UseChaosResult {
+  lastResult: ChaosActionResult | null;
+  isActing: boolean;
+  error: string | null;
+  killCharacter: () => Promise<void>;
+  failQuest: () => Promise<void>;
+  destroyArtifact: () => Promise<void>;
+  drainXp: () => Promise<void>;
+  clearResult: () => void;
+}
+
+export function useChaos(): UseChaosResult {
+  const [lastResult, setLastResult] = useState<ChaosActionResult | null>(null);
+  const [isActing, setIsActing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const clearResult = useCallback(() => {
+    setLastResult(null);
+    setError(null);
+  }, []);
+
+  const killCharacter = useCallback(async () => {
+    setIsActing(true);
+    setError(null);
+    try {
+      const response = await api.post<unknown>('/api/v1/chaos/kill_character');
+      const result = chaosKillResultSchema.parse(response.data);
+      setLastResult({ type: 'kill_character', result });
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to kill character');
+    } finally {
+      setIsActing(false);
+    }
+  }, []);
+
+  const failQuest = useCallback(async () => {
+    setIsActing(true);
+    setError(null);
+    try {
+      const response = await api.post<unknown>('/api/v1/chaos/fail_quest');
+      const result = chaosFailQuestResultSchema.parse(response.data);
+      setLastResult({ type: 'fail_quest', result });
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to fail quest');
+    } finally {
+      setIsActing(false);
+    }
+  }, []);
+
+  const destroyArtifact = useCallback(async () => {
+    setIsActing(true);
+    setError(null);
+    try {
+      const response = await api.post<unknown>('/api/v1/chaos/destroy_artifact');
+      const result = chaosDestroyArtifactResultSchema.parse(response.data);
+      setLastResult({ type: 'destroy_artifact', result });
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to destroy artifact');
+    } finally {
+      setIsActing(false);
+    }
+  }, []);
+
+  const drainXp = useCallback(async () => {
+    setIsActing(true);
+    setError(null);
+    try {
+      const response = await api.post<unknown>('/api/v1/chaos/drain_xp');
+      const result = chaosDrainXpResultSchema.parse(response.data);
+      setLastResult({ type: 'drain_xp', result });
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to drain XP');
+    } finally {
+      setIsActing(false);
+    }
+  }, []);
+
+  return {
+    lastResult,
+    isActing,
+    error,
+    killCharacter,
+    failQuest,
+    destroyArtifact,
+    drainXp,
+    clearResult,
+  };
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -23,6 +23,7 @@ const NAV_LINKS = [
   { to: '/sauron' as const, label: 'SAURON' },
   { to: '/history' as const, label: 'HISTORY' },
   { to: '/simulation' as const, label: 'SIMULATION' },
+  { to: '/chaos' as const, label: 'CHAOS' },
 ];
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/routes/_auth/-chaos.test.tsx
+++ b/frontend/src/routes/_auth/-chaos.test.tsx
@@ -1,0 +1,287 @@
+import { MantineProvider } from '@mantine/core';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock router
+// ---------------------------------------------------------------------------
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    createFileRoute: () => (opts: { component: unknown }) => opts,
+    useNavigate: () => vi.fn(),
+    useSearch: () => ({}),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock useChaos
+// ---------------------------------------------------------------------------
+const mockUseChaos = vi.fn();
+vi.mock('../../hooks/useChaos', () => ({
+  useChaos: () => mockUseChaos(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock notifications
+// ---------------------------------------------------------------------------
+vi.mock('@mantine/notifications', () => ({
+  notifications: { show: vi.fn() },
+}));
+
+// Import components AFTER mocks
+import { ChaosActionCard, ChaosPage, ChaosResultCard } from './chaos';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MantineProvider>{children}</MantineProvider>;
+}
+
+const defaultHook = {
+  lastResult: null,
+  isActing: false,
+  error: null,
+  killCharacter: vi.fn().mockResolvedValue(undefined),
+  failQuest: vi.fn().mockResolvedValue(undefined),
+  destroyArtifact: vi.fn().mockResolvedValue(undefined),
+  drainXp: vi.fn().mockResolvedValue(undefined),
+  clearResult: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// ChaosResultCard
+// ---------------------------------------------------------------------------
+
+describe('ChaosResultCard', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders kill_character result', () => {
+    render(
+      <ChaosResultCard
+        result={{
+          type: 'kill_character',
+          result: { affected: { id: 1, name: 'Boromir', status: 'fallen' } },
+        }}
+      />,
+      { wrapper },
+    );
+    expect(screen.getByTestId('result-card')).toBeInTheDocument();
+    expect(screen.getByTestId('result-details')).toHaveTextContent('Boromir');
+    expect(screen.getByTestId('result-details')).toHaveTextContent('fallen');
+  });
+
+  it('renders fail_quest result', () => {
+    render(
+      <ChaosResultCard
+        result={{
+          type: 'fail_quest',
+          result: { affected: { id: 1, title: 'Destroy the Ring', status: 'failed' } },
+        }}
+      />,
+      { wrapper },
+    );
+    expect(screen.getByTestId('result-details')).toHaveTextContent('Destroy the Ring');
+    expect(screen.getByTestId('result-details')).toHaveTextContent('failed');
+  });
+
+  it('renders destroy_artifact result', () => {
+    render(
+      <ChaosResultCard
+        result={{
+          type: 'destroy_artifact',
+          result: { affected: { id: 1, name: 'The One Ring', artifact_type: 'ring' } },
+        }}
+      />,
+      { wrapper },
+    );
+    expect(screen.getByTestId('result-details')).toHaveTextContent('The One Ring');
+    expect(screen.getByTestId('result-details')).toHaveTextContent('ring');
+  });
+
+  it('renders drain_xp result', () => {
+    render(
+      <ChaosResultCard
+        result={{
+          type: 'drain_xp',
+          result: { characters_affected: 4, xp_drained: 2000 },
+        }}
+      />,
+      { wrapper },
+    );
+    expect(screen.getByTestId('result-details')).toHaveTextContent('4');
+    expect(screen.getByTestId('result-details')).toHaveTextContent('2000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChaosActionCard
+// ---------------------------------------------------------------------------
+
+describe('ChaosActionCard', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders button with correct label', () => {
+    render(
+      <ChaosActionCard
+        title="Kill Character"
+        description="desc"
+        buttonLabel="Kill Character"
+        buttonColor="red"
+        testId="kill-btn"
+        disabled={false}
+        onClick={vi.fn()}
+      />,
+      { wrapper },
+    );
+    expect(screen.getByTestId('kill-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('kill-btn')).toHaveTextContent('Kill Character');
+  });
+
+  it('disables button when disabled=true', () => {
+    render(
+      <ChaosActionCard
+        title="Kill Character"
+        description="desc"
+        buttonLabel="Kill Character"
+        buttonColor="red"
+        testId="kill-btn"
+        disabled={true}
+        onClick={vi.fn()}
+      />,
+      { wrapper },
+    );
+    expect(screen.getByTestId('kill-btn')).toBeDisabled();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(
+      <ChaosActionCard
+        title="Kill Character"
+        description="desc"
+        buttonLabel="Kill Character"
+        buttonColor="red"
+        testId="kill-btn"
+        disabled={false}
+        onClick={onClick}
+      />,
+      { wrapper },
+    );
+    fireEvent.click(screen.getByTestId('kill-btn'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChaosPage
+// ---------------------------------------------------------------------------
+
+describe('ChaosPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders page title', () => {
+    mockUseChaos.mockReturnValue(defaultHook);
+    render(<ChaosPage />, { wrapper });
+    expect(screen.getByText('CHAOS PANEL')).toBeInTheDocument();
+  });
+
+  it('renders all 4 action buttons', () => {
+    mockUseChaos.mockReturnValue(defaultHook);
+    render(<ChaosPage />, { wrapper });
+    expect(screen.getByTestId('kill-character-button')).toBeInTheDocument();
+    expect(screen.getByTestId('fail-quest-button')).toBeInTheDocument();
+    expect(screen.getByTestId('destroy-artifact-button')).toBeInTheDocument();
+    expect(screen.getByTestId('drain-xp-button')).toBeInTheDocument();
+  });
+
+  it('disables all buttons while isActing', () => {
+    mockUseChaos.mockReturnValue({ ...defaultHook, isActing: true });
+    render(<ChaosPage />, { wrapper });
+    expect(screen.getByTestId('kill-character-button')).toBeDisabled();
+    expect(screen.getByTestId('fail-quest-button')).toBeDisabled();
+    expect(screen.getByTestId('destroy-artifact-button')).toBeDisabled();
+    expect(screen.getByTestId('drain-xp-button')).toBeDisabled();
+  });
+
+  it('shows error alert on error', () => {
+    mockUseChaos.mockReturnValue({ ...defaultHook, error: 'No eligible characters to kill' });
+    render(<ChaosPage />, { wrapper });
+    expect(screen.getByTestId('error-alert')).toBeInTheDocument();
+    expect(screen.getByText('No eligible characters to kill')).toBeInTheDocument();
+  });
+
+  it('does not show error alert without error', () => {
+    mockUseChaos.mockReturnValue(defaultHook);
+    render(<ChaosPage />, { wrapper });
+    expect(screen.queryByTestId('error-alert')).not.toBeInTheDocument();
+  });
+
+  it('shows result card when lastResult is set', () => {
+    mockUseChaos.mockReturnValue({
+      ...defaultHook,
+      lastResult: {
+        type: 'kill_character',
+        result: { affected: { id: 1, name: 'Boromir', status: 'fallen' } },
+      },
+    });
+    render(<ChaosPage />, { wrapper });
+    expect(screen.getByTestId('result-card')).toBeInTheDocument();
+  });
+
+  it('does not show result card without lastResult', () => {
+    mockUseChaos.mockReturnValue(defaultHook);
+    render(<ChaosPage />, { wrapper });
+    expect(screen.queryByTestId('result-card')).not.toBeInTheDocument();
+  });
+
+  it('calls killCharacter when kill button is clicked', async () => {
+    const killCharacter = vi.fn().mockResolvedValue(undefined);
+    mockUseChaos.mockReturnValue({ ...defaultHook, killCharacter });
+    render(<ChaosPage />, { wrapper });
+    fireEvent.click(screen.getByTestId('kill-character-button'));
+    await waitFor(() => {
+      expect(killCharacter).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('calls failQuest when fail-quest button is clicked', async () => {
+    const failQuest = vi.fn().mockResolvedValue(undefined);
+    mockUseChaos.mockReturnValue({ ...defaultHook, failQuest });
+    render(<ChaosPage />, { wrapper });
+    fireEvent.click(screen.getByTestId('fail-quest-button'));
+    await waitFor(() => {
+      expect(failQuest).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('calls destroyArtifact when destroy button is clicked', async () => {
+    const destroyArtifact = vi.fn().mockResolvedValue(undefined);
+    mockUseChaos.mockReturnValue({ ...defaultHook, destroyArtifact });
+    render(<ChaosPage />, { wrapper });
+    fireEvent.click(screen.getByTestId('destroy-artifact-button'));
+    await waitFor(() => {
+      expect(destroyArtifact).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('calls drainXp when drain-xp button is clicked', async () => {
+    const drainXp = vi.fn().mockResolvedValue(undefined);
+    mockUseChaos.mockReturnValue({ ...defaultHook, drainXp });
+    render(<ChaosPage />, { wrapper });
+    fireEvent.click(screen.getByTestId('drain-xp-button'));
+    await waitFor(() => {
+      expect(drainXp).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/routes/_auth/chaos.tsx
+++ b/frontend/src/routes/_auth/chaos.tsx
@@ -1,0 +1,223 @@
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Container,
+  Group,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { createFileRoute } from '@tanstack/react-router';
+import { type ChaosActionResult, useChaos } from '../../hooks/useChaos';
+
+export const Route = createFileRoute('/_auth/chaos')({
+  component: ChaosPage,
+});
+
+// ---------------------------------------------------------------------------
+// Result display
+// ---------------------------------------------------------------------------
+
+function formatResult(result: ChaosActionResult): { label: string; details: string } {
+  switch (result.type) {
+    case 'kill_character':
+      return {
+        label: 'Character killed',
+        details: `${result.result.affected.name} is now ${result.result.affected.status}`,
+      };
+    case 'fail_quest':
+      return {
+        label: 'Quest failed',
+        details: `"${result.result.affected.title}" — status: ${result.result.affected.status}`,
+      };
+    case 'destroy_artifact':
+      return {
+        label: 'Artifact destroyed',
+        details: `${result.result.affected.name} (${result.result.affected.artifact_type}) has been obliterated`,
+      };
+    case 'drain_xp':
+      return {
+        label: 'XP drained',
+        details: `${result.result.characters_affected} character(s) lost ${result.result.xp_drained} XP total`,
+      };
+  }
+}
+
+interface ResultCardProps {
+  result: ChaosActionResult;
+}
+
+export function ChaosResultCard({ result }: ResultCardProps) {
+  const { label, details } = formatResult(result);
+  return (
+    <Card shadow="sm" padding="md" radius="md" withBorder data-testid="result-card">
+      <Group gap="sm" align="center">
+        <Badge color="red" variant="filled" size="lg">
+          CHAOS APPLIED
+        </Badge>
+        <Text fw={600}>{label}</Text>
+      </Group>
+      <Text mt="xs" c="dimmed" size="sm" data-testid="result-details">
+        {details}
+      </Text>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chaos action card
+// ---------------------------------------------------------------------------
+
+interface ActionCardProps {
+  title: string;
+  description: string;
+  buttonLabel: string;
+  buttonColor: string;
+  testId: string;
+  disabled: boolean;
+  onClick: () => void;
+}
+
+export function ChaosActionCard({
+  title,
+  description,
+  buttonLabel,
+  buttonColor,
+  testId,
+  disabled,
+  onClick,
+}: ActionCardProps) {
+  return (
+    <Card shadow="sm" padding="md" radius="md" withBorder>
+      <Stack gap="sm">
+        <Title order={5}>{title}</Title>
+        <Text size="sm" c="dimmed">
+          {description}
+        </Text>
+        <Button
+          color={buttonColor}
+          disabled={disabled}
+          onClick={onClick}
+          data-testid={testId}
+          fullWidth
+        >
+          {buttonLabel}
+        </Button>
+      </Stack>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export function ChaosPage() {
+  const { lastResult, isActing, error, killCharacter, failQuest, destroyArtifact, drainXp } =
+    useChaos();
+
+  async function handleKillCharacter() {
+    await killCharacter();
+    notifications.show({
+      title: 'Chaos injected',
+      message: 'A character has been slain.',
+      color: 'red',
+    });
+  }
+
+  async function handleFailQuest() {
+    await failQuest();
+    notifications.show({
+      title: 'Chaos injected',
+      message: 'A quest has been failed.',
+      color: 'red',
+    });
+  }
+
+  async function handleDestroyArtifact() {
+    await destroyArtifact();
+    notifications.show({
+      title: 'Chaos injected',
+      message: 'An artifact has been destroyed.',
+      color: 'red',
+    });
+  }
+
+  async function handleDrainXp() {
+    await drainXp();
+    notifications.show({
+      title: 'Chaos injected',
+      message: 'XP has been drained from the fellowship.',
+      color: 'orange',
+    });
+  }
+
+  return (
+    <Container size="md">
+      <Title order={2} mb="xs">
+        CHAOS PANEL
+      </Title>
+      <Text c="dimmed" mb="md" size="sm">
+        Inject failure scenarios for disaster recovery training. All actions are irreversible.
+      </Text>
+
+      {error && (
+        <Alert color="red" title="Chaos injection failed" mb="md" data-testid="error-alert">
+          {error}
+        </Alert>
+      )}
+
+      {lastResult && (
+        <Stack mb="md">
+          <ChaosResultCard result={lastResult} />
+        </Stack>
+      )}
+
+      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+        <ChaosActionCard
+          title="Kill Character"
+          description="Sets a random non-fallen character to fallen, removing them from active service."
+          buttonLabel="Kill Character"
+          buttonColor="red"
+          testId="kill-character-button"
+          disabled={isActing}
+          onClick={handleKillCharacter}
+        />
+
+        <ChaosActionCard
+          title="Fail Quest"
+          description="Fails a random active quest and returns its surviving members to idle."
+          buttonLabel="Fail Quest"
+          buttonColor="orange"
+          testId="fail-quest-button"
+          disabled={isActing}
+          onClick={handleFailQuest}
+        />
+
+        <ChaosActionCard
+          title="Destroy Artifact"
+          description="Permanently destroys a random artifact — gone from the world forever."
+          buttonLabel="Destroy Artifact"
+          buttonColor="grape"
+          testId="destroy-artifact-button"
+          disabled={isActing}
+          onClick={handleDestroyArtifact}
+        />
+
+        <ChaosActionCard
+          title="Drain XP"
+          description="Drains 50% XP from all non-fallen characters across the fellowship."
+          buttonLabel="Drain XP"
+          buttonColor="yellow"
+          testId="drain-xp-button"
+          disabled={isActing}
+          onClick={handleDrainXp}
+        />
+      </SimpleGrid>
+    </Container>
+  );
+}

--- a/frontend/src/schemas/chaos.ts
+++ b/frontend/src/schemas/chaos.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Chaos injection result schemas
+// ---------------------------------------------------------------------------
+
+export const chaosKillResultSchema = z.object({
+  affected: z.object({
+    id: z.number(),
+    name: z.string(),
+    status: z.string(),
+  }),
+});
+
+export const chaosFailQuestResultSchema = z.object({
+  affected: z.object({
+    id: z.number(),
+    title: z.string(),
+    status: z.string(),
+  }),
+});
+
+export const chaosDestroyArtifactResultSchema = z.object({
+  affected: z.object({
+    id: z.number(),
+    name: z.string(),
+    artifact_type: z.string(),
+  }),
+});
+
+export const chaosDrainXpResultSchema = z.object({
+  characters_affected: z.number(),
+  xp_drained: z.number(),
+});
+
+export type ChaosKillResult = z.infer<typeof chaosKillResultSchema>;
+export type ChaosFailQuestResult = z.infer<typeof chaosFailQuestResultSchema>;
+export type ChaosDestroyArtifactResult = z.infer<typeof chaosDestroyArtifactResultSchema>;
+export type ChaosDrainXpResult = z.infer<typeof chaosDrainXpResultSchema>;
+
+export type ChaosActionResult =
+  | { type: 'kill_character'; result: ChaosKillResult }
+  | { type: 'fail_quest'; result: ChaosFailQuestResult }
+  | { type: 'destroy_artifact'; result: ChaosDestroyArtifactResult }
+  | { type: 'drain_xp'; result: ChaosDrainXpResult };


### PR DESCRIPTION
## Summary

Implements 4 chaos injection POST endpoints (`ChaosController`) for disaster recovery training, with full RSwag API documentation, a Chaos Panel frontend UI, and comprehensive test coverage.

## Changes

### Backend
- **`ChaosController`** — 4 new POST endpoints:
  - `POST /api/v1/chaos/kill_character` — sets a random non-fallen character to `fallen`
  - `POST /api/v1/chaos/fail_quest` — fails a random active quest and returns surviving members to `idle`
  - `POST /api/v1/chaos/destroy_artifact` — permanently deletes a random artifact
  - `POST /api/v1/chaos/drain_xp` — drains 50% XP from all non-fallen characters
- All endpoints return `{ error: "..." }` with HTTP 422 when no eligible records exist (matches `ErrorResponse` schema throughout codebase)
- **Routes** — 4 chaos routes added to `config/routes.rb` under `namespace :v1`
- **RSwag integration spec** (`spec/integration/chaos_spec.rb`) — 8 examples covering 200 + 422 for each endpoint
- **RSpec request spec** (`spec/requests/api/v1/chaos_spec.rb`) — 29 examples covering happy paths and all edge cases
- **`swagger_helper.rb`** — 4 new schemas: `ChaosKillResult`, `ChaosFailQuestResult`, `ChaosDestroyArtifactResult`, `ChaosDrainXpResult`
- **`swagger/v1/swagger.yaml`** — regenerated via `bundle exec rake rswag:specs:swaggerize`

### Frontend
- **`src/schemas/chaos.ts`** — Zod schemas for all 4 chaos response types
- **`src/hooks/useChaos.ts`** — `useChaos` hook with `killCharacter`, `failQuest`, `destroyArtifact`, `drainXp` actions
- **`src/routes/_auth/chaos.tsx`** — `ChaosPage` at `/chaos` with 4 `ChaosActionCard` components and `ChaosResultCard` result display; `ChaosActionCard` and `ChaosResultCard` are exported for testing
- **`src/routes/_auth/-chaos.test.tsx`** — 18 Vitest tests for `ChaosResultCard`, `ChaosActionCard`, and `ChaosPage`
- **`src/routes/__root.tsx`** — Added `CHAOS` nav link

## Testing

- **Backend**: 685 RSpec examples, 0 failures (includes 29 new + 8 integration)
- **Frontend**: 229 Vitest tests, 0 failures (includes 18 new)
- **Biome lint**: 0 errors (2 pre-existing warnings in unrelated file)
- **swagger.yaml**: regenerated via rake task — no hand-editing

## Story

Closes #150

-- Devon (HiveLabs developer agent)