### PR TITLE
fix: enforce character level default of 1 and backfill existing rows

### DIFF
--- a/backend/app/models/character.rb
+++ b/backend/app/models/character.rb
@@ -3,6 +3,10 @@
 class Character < ApplicationRecord
   enum :status, { idle: "idle", on_quest: "on_quest", fallen: "fallen" }, default: "idle"
 
+  # Explicit model-level default so that Character.new without a level
+  # argument is always valid even before the DB connection resolves defaults.
+  attribute :level, :integer, default: 1
+
   has_many :quest_memberships, dependent: :destroy
   has_many :quests, through: :quest_memberships
   has_many :artifacts, dependent: :nullify

--- a/backend/db/migrate/20260325000001_fix_character_level_default.rb
+++ b/backend/db/migrate/20260325000001_fix_character_level_default.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Defensive migration: ensure the `level` column on `characters` has a
+# DB-level default of 1 and backfill any existing rows where level is nil
+# or less than 1.  This prevents `QuestTickWorker` from raising
+# `ActiveRecord::RecordInvalid: Validation failed: Level must be greater than 0`
+# when processing characters that were created before this default was enforced.
+class FixCharacterLevelDefault < ActiveRecord::Migration[8.1]
+  def up
+    # Ensure the DB-level default is 1 (idempotent: safe to run even if already 1)
+    change_column_default :characters, :level, from: 0, to: 1
+
+    # Backfill any existing rows that have a nil or zero level
+    Character.where("level IS NULL OR level < 1").update_all(level: 1)
+  end
+
+  def down
+    change_column_default :characters, :level, from: 1, to: 0
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_19_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_25_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
## Summary

- Add migration `20260325000001_fix_character_level_default` to ensure the `characters.level` DB column default is `1` and backfill any existing rows where `level` is `nil` or `< 1`
- Add explicit model-level `attribute :level, :integer, default: 1` to `Character` so `Character.new` always initialises with `level = 1` even before the DB connection resolves column defaults
- Update `db/schema.rb` to schema version `2026_03_25_000001`

## Changes

### `backend/db/migrate/20260325000001_fix_character_level_default.rb` (new)
- `change_column_default :characters, :level, from: 0, to: 1` — idempotent DDL ensuring the DB default is `1`
- `Character.where("level IS NULL OR level < 1").update_all(level: 1)` — backfill guard against stale rows

### `backend/app/models/character.rb`
- Added `attribute :level, :integer, default: 1` for in-memory default, complementing the DB-level default

### `backend/db/schema.rb`
- Bumped schema version to `2026_03_25_000001` (auto-generated by `rails db:schema:dump`)

## Testing

- Ran `bundle exec rspec` in Docker — **648 examples, 0 failures**
- Existing `Character` model spec "defaults level to 1" continues to pass, confirming `Character.new(name: "X", race: "Y").level == 1`
- Existing `QuestTickWorker` specs (58 examples) all pass

## Story

Closes #162

-- Devon (HiveLabs developer agent)