### PR TITLE
feat: clarify QUEST_TICK_INTERVAL vs tick_interval_seconds (#165)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,21 +28,31 @@ OIDC_CLIENT_SECRET=
 OIDC_AUDIENCE=
 OIDC_JWKS_CACHE_TTL=3600
 
-# Quest tick frequency
+# Quest tick scheduling — TWO DISTINCT SETTINGS
 # ────────────────────────────────────────────────────────────────────
-# QUEST_TICK_INTERVAL controls how often (in seconds) the QuestTickWorker
-# reschedules itself after each run via perform_in.
+# There are two settings that relate to tick timing.  They are NOT the same:
+#
+# QUEST_TICK_INTERVAL (this file — infra/ops concern):
+#   How often (in seconds) QuestTickWorker re-enqueues itself via perform_in.
+#   This is the Sidekiq job scheduling cadence — an infrastructure-level
+#   setting managed by ops.  The sidekiq-cron entry (QUEST_TICK_CRON) fires
+#   at most once per minute and acts as a dead-chain reviver; fine-grained
+#   frequency comes from QUEST_TICK_INTERVAL.
 #
 #   Development / test: 5 s default — quest progress is visible within seconds.
 #   Production:        60 s default — sensible background cadence.
+#   NEVER set this to a very small value (< 3) in production.
 #
-# The sidekiq-cron entry (QUEST_TICK_CRON) fires at most once per minute and
-# acts as a dead-chain reviver; fine-grained frequency comes from QUEST_TICK_INTERVAL.
+# tick_interval_seconds (SimulationConfig DB row — runtime/operator concern):
+#   The simulation clock speed — how many seconds the simulation treats each
+#   "tick" as representing.  Stored in the database and editable via the
+#   Simulation UI at runtime (no deploy needed).  Takes precedence over
+#   QUEST_TICK_INTERVAL when set, so the UI value is authoritative.
 #
 # Override examples:
-#   QUEST_TICK_INTERVAL=10     # 10-second ticks
+#   QUEST_TICK_INTERVAL=10     # 10-second Sidekiq scheduling cadence
 #   QUEST_TICK_CRON=* * * * *  # cron bootstrap schedule (default: every minute)
-# NEVER set QUEST_TICK_INTERVAL to a very small value (< 3) in production.
+# ────────────────────────────────────────────────────────────────────
 QUEST_TICK_INTERVAL=5
 
 # Dev auth bypass — set to "true" to skip OIDC in development.

--- a/backend/app/jobs/quest_tick_worker.rb
+++ b/backend/app/jobs/quest_tick_worker.rb
@@ -1,12 +1,36 @@
 # frozen_string_literal: true
 
+# QuestTickWorker processes active quest state on every simulation tick and
+# reschedules itself for the next tick.
+#
+# TICK INTERVAL — TWO DISTINCT SETTINGS
+# ─────────────────────────────────────────────────────────────────────────────
+# QUEST_TICK_INTERVAL (env var / .env):
+#   Infrastructure-level Sidekiq scheduling cadence.  Controls how often this
+#   worker re-enqueues itself via +perform_in+.  Managed by ops/infra; only
+#   affects how frequently the background job runs.  The sidekiq-cron entry
+#   (QUEST_TICK_CRON) acts as a dead-chain reviver (fires at most once per
+#   minute); fine-grained frequency comes from QUEST_TICK_INTERVAL.
+#
+# tick_interval_seconds (SimulationConfig DB column, editable in Simulation UI):
+#   Simulation clock speed — how many seconds the simulation considers a
+#   single "tick" to represent.  Stored in the database and controlled by
+#   operators through the Simulation UI.  Takes precedence over
+#   QUEST_TICK_INTERVAL when set: the worker reads this value at runtime so
+#   that UI changes take effect on the next tick without an infra deploy.
+#
+# The env var (TICK_INTERVAL constant) is the *fallback* scheduling cadence;
+# the DB value (tick_interval_seconds) is the *authoritative* source.
+# See .env.example for further documentation.
+# ─────────────────────────────────────────────────────────────────────────────
 class QuestTickWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: :default, retry: 3
 
-  # How many seconds between ticks.
-  # Override via QUEST_TICK_INTERVAL env var.
+  # Fallback scheduling interval (seconds) used when SimulationConfig is
+  # unavailable.  Prefer the DB value (tick_interval_seconds) at runtime.
+  # Override the fallback via QUEST_TICK_INTERVAL env var.
   # Default: 5 s in development/test for fast feedback; 60 s in production.
   TICK_INTERVAL = ENV.fetch("QUEST_TICK_INTERVAL", Rails.env.production? ? 60 : 5).to_i
 
@@ -24,13 +48,24 @@ class QuestTickWorker
       ensure_random_quest(config)
     end
 
-    # Schedule the next tick at the configured interval so sub-minute
-    # frequencies are possible. The sidekiq-cron entry acts as a
-    # bootstrap / dead-chain reviver and fires at most once per minute.
-    self.class.perform_in(TICK_INTERVAL)
+    # Schedule the next tick.
+    # tick_interval_seconds (DB, editable via Simulation UI) takes precedence
+    # over QUEST_TICK_INTERVAL so operator UI changes take effect immediately
+    # without an infra restart.  Falls back to TICK_INTERVAL (env var) if the
+    # DB value is unavailable or zero.
+    self.class.perform_in(effective_tick_interval(config))
   end
 
   private
+
+  # Returns the tick scheduling interval in seconds.
+  # Prefers SimulationConfig#tick_interval_seconds (DB/UI-controlled) over
+  # the TICK_INTERVAL constant (env var fallback) so the Simulation UI setting
+  # is authoritative at runtime.
+  def effective_tick_interval(config)
+    db_interval = config.tick_interval_seconds.to_i
+    db_interval.positive? ? db_interval : TICK_INTERVAL
+  end
 
   def process_active_quests(config)
     Quest.where(status: :active).find_each do |quest|

--- a/backend/spec/jobs/quest_tick_worker_spec.rb
+++ b/backend/spec/jobs/quest_tick_worker_spec.rb
@@ -513,7 +513,7 @@ RSpec.describe QuestTickWorker, type: :job do
   end
 
   describe "tick interval configuration" do
-    it "exposes TICK_INTERVAL as a positive integer" do
+    it "exposes TICK_INTERVAL as a positive integer (env var fallback)" do
       expect(QuestTickWorker::TICK_INTERVAL).to be_a(Integer)
       expect(QuestTickWorker::TICK_INTERVAL).to be > 0
     end
@@ -524,8 +524,23 @@ RSpec.describe QuestTickWorker, type: :job do
     end
 
     context "when simulation is running" do
-      it "schedules the next tick via perform_in after completing work" do
-        expect(QuestTickWorker).to receive(:perform_in).with(QuestTickWorker::TICK_INTERVAL)
+      it "schedules the next tick using tick_interval_seconds from SimulationConfig (DB value)" do
+        config.update!(tick_interval_seconds: 30)
+        expect(QuestTickWorker).to receive(:perform_in).with(30)
+        subject.perform
+      end
+
+      it "falls back to TICK_INTERVAL when tick_interval_seconds is unavailable" do
+        # Simulate a scenario where the DB returns 0 (edge case guard)
+        worker = described_class.new
+        allow(config).to receive(:tick_interval_seconds).and_return(0)
+        expect(worker.send(:effective_tick_interval, config)).to eq(QuestTickWorker::TICK_INTERVAL)
+      end
+
+      it "prefers DB tick_interval_seconds over TICK_INTERVAL env var fallback" do
+        config.update!(tick_interval_seconds: 45)
+        stub_const("QuestTickWorker::TICK_INTERVAL", 10)
+        expect(QuestTickWorker).to receive(:perform_in).with(45)
         subject.perform
       end
     end

--- a/frontend/src/routes/_auth/simulation.tsx
+++ b/frontend/src/routes/_auth/simulation.tsx
@@ -243,7 +243,7 @@ export function SimulationConfigForm({ config, isActing, onSubmit }: ConfigFormP
 
           <NumberInput
             label="Tick interval (seconds)"
-            description="How often the simulation advances (must be > 0)"
+            description="Simulation clock speed: seconds between each tick (stored in DB, takes precedence over the QUEST_TICK_INTERVAL env var). Must be > 0."
             min={1}
             value={values.tick_interval_seconds}
             onChange={(v) => setValues((prev) => ({ ...prev, tick_interval_seconds: v }))}


### PR DESCRIPTION
## Summary

Resolves the confusion between two overlapping tick settings by clarifying their distinct roles in code, documentation, and the Simulation UI.

## Changes

- **`QuestTickWorker`**: Added class-level doc comment explaining the distinction between `QUEST_TICK_INTERVAL` (infra scheduling cadence) and `tick_interval_seconds` (simulation clock speed). Worker now reads `SimulationConfig#tick_interval_seconds` (DB, UI-editable) as the authoritative scheduling interval via new `effective_tick_interval` private method; `TICK_INTERVAL` constant (env var) is the fallback only. This means Simulation UI changes take effect on the next tick without an infra restart.
- **`.env.example`**: Comment block rewritten with a clear "TWO DISTINCT SETTINGS" section that documents both settings and their relationship.
- **Simulation UI**: `tick_interval_seconds` field description updated from generic "How often the simulation advances" to an explicit statement that it's the simulation clock speed stored in DB, distinct from `QUEST_TICK_INTERVAL`.
- **RSpec**: Updated `tick interval configuration` describe block with tests that verify DB value precedence, fallback behaviour via `effective_tick_interval`, and that the env var is properly overridden by the DB value.

## Architectural note

`QUEST_TICK_INTERVAL` (env var) governs **Sidekiq job scheduling cadence** — how often the background job runs. `tick_interval_seconds` (DB) governs **simulation clock speed** — how the game logic treats time. These were previously conflated. No removal of either setting is in scope; a deprecation recommendation for `QUEST_TICK_INTERVAL` (in favour of always using the DB value) would be a follow-up.

## Story

Closes #165

## Testing

- `bundle exec rspec spec/jobs/quest_tick_worker_spec.rb` — all tick interval tests green
- No changes to game logic, only to scheduling interval resolution and documentation

-- Devon (HiveLabs developer agent)