### PR TITLE
fix: show 100% progress bar for completed quests

### DIFF
--- a/frontend/src/components/QuestCard.test.tsx
+++ b/frontend/src/components/QuestCard.test.tsx
@@ -151,4 +151,38 @@ describe('QuestCard', () => {
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
+
+  it('shows progress bar at 100% for completed quest with null progress', () => {
+    const completedQuest: Quest = {
+      ...sampleQuest,
+      status: 'completed',
+      progress: null,
+    };
+    render(<QuestCard quest={completedQuest} onClick={vi.fn()} />, { wrapper });
+
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toBeInTheDocument();
+    expect(bar).toHaveAttribute('aria-valuenow', '100');
+    expect(bar).toHaveAttribute('aria-label', 'Quest progress: 100%');
+  });
+
+  it('shows progress bar at 100% for completed quest with stale zero progress', () => {
+    const completedQuest: Quest = {
+      ...sampleQuest,
+      status: 'completed',
+      progress: 0,
+    };
+    render(<QuestCard quest={completedQuest} onClick={vi.fn()} />, { wrapper });
+
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toBeInTheDocument();
+    expect(bar).toHaveAttribute('aria-valuenow', '100');
+    expect(bar).toHaveAttribute('aria-label', 'Quest progress: 100%');
+  });
+
+  it('does not show progress bar for pending quests with null progress', () => {
+    render(<QuestCard quest={sampleQuest} onClick={vi.fn()} />, { wrapper });
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/QuestCard.tsx
+++ b/frontend/src/components/QuestCard.tsx
@@ -37,6 +37,7 @@ function dangerColor(level: number): string {
 export function QuestCard({ quest, onClick, onAdvance }: QuestCardProps) {
   const statusColor = STATUS_COLORS[quest.status] ?? 'gray';
   const nextStatus = STATUS_TRANSITIONS[quest.status];
+  const effectiveProgress = quest.status === 'completed' ? 100 : quest.progress;
 
   return (
     <Card
@@ -78,13 +79,13 @@ export function QuestCard({ quest, onClick, onAdvance }: QuestCardProps) {
           )}
         </Group>
 
-        {quest.progress != null && (
+        {effectiveProgress != null && (
           <Progress
-            value={quest.progress}
+            value={effectiveProgress}
             size="sm"
             color={STATUS_COLORS[quest.status] ?? 'gray'}
-            aria-label={`Quest progress: ${Math.round(quest.progress)}%`}
-            aria-valuenow={quest.progress}
+            aria-label={`Quest progress: ${Math.round(effectiveProgress)}%`}
+            aria-valuenow={effectiveProgress}
             aria-valuemin={0}
             aria-valuemax={100}
           />

--- a/frontend/src/components/QuestDetailModal.test.tsx
+++ b/frontend/src/components/QuestDetailModal.test.tsx
@@ -112,4 +112,24 @@ describe('QuestDetailModal', () => {
     expect(screen.queryByTestId('no-members-message')).not.toBeInTheDocument();
     expect(screen.queryByText('Members')).not.toBeInTheDocument();
   });
+
+  it('shows progress bar at 100% for completed quest with null progress', () => {
+    const completedQuest: Quest = { ...sampleQuest, status: 'completed', progress: null };
+    render(<QuestDetailModal quest={completedQuest} onClose={vi.fn()} />, { wrapper });
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('shows progress bar at 100% for completed quest with stale zero progress', () => {
+    const completedQuest: Quest = { ...sampleQuest, status: 'completed', progress: 0 };
+    render(<QuestDetailModal quest={completedQuest} onClose={vi.fn()} />, { wrapper });
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('does not show progress bar for pending quest with null progress', () => {
+    render(<QuestDetailModal quest={sampleQuest} onClose={vi.fn()} />, { wrapper });
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/QuestDetailModal.tsx
+++ b/frontend/src/components/QuestDetailModal.tsx
@@ -31,6 +31,7 @@ export function QuestDetailModal({ quest, onClose, onStart }: QuestDetailModalPr
   if (!quest) return null;
 
   const statusColor = STATUS_COLORS[quest.status] ?? 'gray';
+  const effectiveProgress = quest.status === 'completed' ? 100 : quest.progress;
 
   return (
     <Modal
@@ -72,12 +73,12 @@ export function QuestDetailModal({ quest, onClose, onStart }: QuestDetailModalPr
           <StatItem label="Attempts" value={quest.attempts} />
         </Group>
 
-        {quest.progress != null && (
+        {effectiveProgress != null && (
           <Stack gap={4}>
             <Text size="xs" c="dimmed">
               Progress
             </Text>
-            <Progress value={quest.progress} size="md" color="blue" />
+            <Progress value={effectiveProgress} size="md" color={statusColor} />
           </Stack>
         )}
 


### PR DESCRIPTION
## Summary
- Completed quests with `null` or stale `0` progress now always render a full (100%) progress bar
- Derived `effectiveProgress` variable computed before JSX: `quest.status === 'completed' ? 100 : quest.progress` — clean, Biome-compliant, no IIFE needed
- `QuestDetailModal` progress bar color now follows status color (was hardcoded `blue`)

## Changes
- `frontend/src/components/QuestCard.tsx` — compute `effectiveProgress` and guard on `effectiveProgress != null`
- `frontend/src/components/QuestDetailModal.tsx` — same pattern; color follows `statusColor`
- `frontend/src/components/QuestCard.test.tsx` — 3 new tests: completed/null-progress shows 100%, completed/zero-progress shows 100%, pending/null-progress shows no bar
- `frontend/src/components/QuestDetailModal.test.tsx` — 3 matching new tests for the modal view

## Story link
Closes #171

## Testing instructions
1. Run `npm run lint` in `frontend/` — passes with zero errors
2. Run `npm run test` in `frontend/` — 235 tests pass across 27 files (up from 229)
3. Manually: open a quest detail modal for a `completed` quest → progress bar shows full green at 100%

-- Devon (HiveLabs developer agent)