### PR TITLE
fix: wire ActionCable live updates on quest page (#172)

### DIFF
--- a/frontend/src/hooks/useQuestEventsChannel.ts
+++ b/frontend/src/hooks/useQuestEventsChannel.ts
@@ -5,8 +5,13 @@ import { useActionCable } from './useActionCable';
 export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'reconnecting';
 
 export interface QuestEvent {
-  type: string;
+  event_type: string;
   quest_id?: number;
+  quest_name?: string;
+  region?: string;
+  message?: string;
+  data?: Record<string, unknown>;
+  occurred_at?: string;
   // biome-ignore lint/suspicious/noExplicitAny: mirrors Action Cable's BaseMixin.received signature
   [key: string]: any;
 }

--- a/frontend/src/routes/_auth/-quests.test.tsx
+++ b/frontend/src/routes/_auth/-quests.test.tsx
@@ -1,5 +1,5 @@
 import { MantineProvider } from '@mantine/core';
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -244,5 +244,209 @@ describe('QuestsPage', () => {
 
     expect(screen.getByText('Advance → Active')).toBeInTheDocument();
     expect(screen.getByText('Advance → Completed')).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Live update tests — verify ActionCable event patches are applied correctly.
+  // The broadcast payload shape from QuestEventBroadcaster is:
+  //   { event_type, quest_id, quest_name, region, message, data, occurred_at }
+  // Progress is nested in data.progress (0.0–1.0); status is derived from event_type.
+  // ---------------------------------------------------------------------------
+  describe('live updates via ActionCable', () => {
+    it('updates quest progress from a progress event (data.progress)', () => {
+      const quests = [{ ...sampleQuests[1], id: 2, status: 'active', progress: 0.3 }];
+      mockUseQuests.mockReturnValue({
+        quests,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: {
+          event_type: 'progress',
+          quest_id: 2,
+          data: { progress: 0.75, increment: 0.05 },
+        },
+        connectionStatus: 'connected',
+      });
+
+      render(<QuestsPage />, { wrapper });
+
+      const bar = screen.getByRole('progressbar');
+      expect(bar).toHaveAttribute('aria-valuenow', '0.75');
+    });
+
+    it('updates quest status to completed from a completed event', () => {
+      const quests = [{ ...sampleQuests[1], id: 2, status: 'active', progress: 0.9 }];
+      mockUseQuests.mockReturnValue({
+        quests,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: {
+          event_type: 'completed',
+          quest_id: 2,
+          data: { xp_awarded: 200, result: 'success' },
+        },
+        connectionStatus: 'connected',
+      });
+
+      render(<QuestsPage />, { wrapper });
+
+      expect(screen.getByText('completed')).toBeInTheDocument();
+    });
+
+    it('updates quest status to failed from a failed event', () => {
+      const quests = [{ ...sampleQuests[1], id: 2, status: 'active', progress: 0.5 }];
+      mockUseQuests.mockReturnValue({
+        quests,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: {
+          event_type: 'failed',
+          quest_id: 2,
+          data: { xp_awarded: 50, result: 'failure' },
+        },
+        connectionStatus: 'connected',
+      });
+
+      render(<QuestsPage />, { wrapper });
+
+      expect(screen.getByText('failed')).toBeInTheDocument();
+    });
+
+    it('updates quest status to active and resets progress from a restarted event', () => {
+      const quests = [{ ...sampleQuests[1], id: 2, status: 'failed', progress: 0.5 }];
+      mockUseQuests.mockReturnValue({
+        quests,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: {
+          event_type: 'restarted',
+          quest_id: 2,
+          data: { attempt: 2 },
+        },
+        connectionStatus: 'connected',
+      });
+
+      render(<QuestsPage />, { wrapper });
+
+      expect(screen.getByText('active')).toBeInTheDocument();
+      const bar = screen.getByRole('progressbar');
+      expect(bar).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('updates quest status to active from a started event', () => {
+      const quests = [{ ...sampleQuests[0], id: 1, status: 'pending', progress: null }];
+      mockUseQuests.mockReturnValue({
+        quests,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: {
+          event_type: 'started',
+          quest_id: 1,
+          data: { party: ['Frodo', 'Sam'] },
+        },
+        connectionStatus: 'connected',
+      });
+
+      render(<QuestsPage />, { wrapper });
+
+      expect(screen.getByText('active')).toBeInTheDocument();
+    });
+
+    it('does not patch quests when event has no matching quest_id', () => {
+      mockUseQuests.mockReturnValue({
+        quests: sampleQuests,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: {
+          event_type: 'completed',
+          quest_id: 9999,
+          data: {},
+        },
+        connectionStatus: 'connected',
+      });
+
+      render(<QuestsPage />, { wrapper });
+
+      // Original statuses remain untouched.
+      expect(screen.getByText('pending')).toBeInTheDocument();
+      expect(screen.getByText('active')).toBeInTheDocument();
+    });
+
+    it('ignores unknown event types without patching status', () => {
+      const quests = [{ ...sampleQuests[1], id: 2, status: 'active', progress: 0.4 }];
+      mockUseQuests.mockReturnValue({
+        quests,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: {
+          event_type: 'level_up',
+          quest_id: 2,
+          data: { character_name: 'Frodo', new_level: 5 },
+        },
+        connectionStatus: 'connected',
+      });
+
+      render(<QuestsPage />, { wrapper });
+
+      // Status stays active — level_up events don't change quest status.
+      expect(screen.getByText('active')).toBeInTheDocument();
+    });
+
+    it('updates quest progress reactively when latestEvent changes', () => {
+      const quests = [{ ...sampleQuests[1], id: 2, status: 'active', progress: 0.2 }];
+      mockUseQuests.mockReturnValue({
+        quests,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: null,
+        connectionStatus: 'connected',
+      });
+
+      const { rerender } = render(<QuestsPage />, { wrapper });
+
+      // Quest progress bar reflects initial seeded value.
+      let bar = screen.getByRole('progressbar');
+      expect(bar).toHaveAttribute('aria-valuenow', '0.2');
+
+      // Simulate receiving a live progress tick.
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: {
+          event_type: 'progress',
+          quest_id: 2,
+          data: { progress: 0.55, increment: 0.05 },
+        },
+        connectionStatus: 'connected',
+      });
+
+      act(() => {
+        rerender(<QuestsPage />);
+      });
+
+      bar = screen.getByRole('progressbar');
+      expect(bar).toHaveAttribute('aria-valuenow', '0.55');
+    });
   });
 });

--- a/frontend/src/routes/_auth/quests.tsx
+++ b/frontend/src/routes/_auth/quests.tsx
@@ -89,16 +89,42 @@ export function QuestsPage() {
   }, [quests, isLoading]);
 
   // Apply real-time patch updates from QuestEventsChannel.
+  // The broadcast payload shape (from QuestEventBroadcaster) is:
+  //   { event_type, quest_id, quest_name, region, message, data, occurred_at }
+  // Progress ticks arrive as event_type "progress" with data.progress (0.0–1.0).
+  // Status transitions arrive as event_type "completed" | "failed" | "started" | "restarted".
   useEffect(() => {
     if (!latestEvent) return;
 
     const patch: Partial<Quest> = {};
-    if ('status' in latestEvent && typeof latestEvent.status === 'string') {
-      patch.status = latestEvent.status as Quest['status'];
+
+    // Derive status from event_type.
+    const eventType =
+      'event_type' in latestEvent && typeof latestEvent.event_type === 'string'
+        ? latestEvent.event_type
+        : null;
+
+    if (eventType === 'completed') {
+      patch.status = 'completed';
+    } else if (eventType === 'failed') {
+      patch.status = 'failed';
+    } else if (eventType === 'started') {
+      patch.status = 'active';
+    } else if (eventType === 'restarted') {
+      patch.status = 'active';
+      patch.progress = 0;
     }
-    if ('progress' in latestEvent && typeof latestEvent.progress === 'number') {
-      patch.progress = latestEvent.progress;
+
+    // Read live progress value from data.progress (backend sends 0.0–1.0).
+    const eventData =
+      'data' in latestEvent && latestEvent.data !== null && typeof latestEvent.data === 'object'
+        ? (latestEvent.data as Record<string, unknown>)
+        : null;
+
+    if (eventData !== null && 'progress' in eventData && typeof eventData.progress === 'number') {
+      patch.progress = eventData.progress;
     }
+
     if (Object.keys(patch).length === 0) return;
 
     const applyPatch = (q: Quest): Quest =>


### PR DESCRIPTION
## Summary

- The quest page was already subscribed to `QuestEventsChannel` via `useQuestEventsChannel`, but the real-time patch effect was reading the wrong fields from the broadcast payload
- `QuestEventBroadcaster` sends `event_type` (not `status`) and nests progress inside `data.progress` (not at the top level), so neither the status nor the progress patches ever fired
- Players had to manually reload to see quest progress — this fixes that

## Changes

**`frontend/src/routes/_auth/quests.tsx`**
- Rewrote the `latestEvent` patch `useEffect` to derive quest `status` from `event_type` (`completed`, `failed`, `started`, `restarted`) and read `progress` from `data.progress`
- `restarted` events now also reset `progress` to `0`

**`frontend/src/hooks/useQuestEventsChannel.ts`**
- Corrected the `QuestEvent` interface: renamed `type` → `event_type` and added the broadcast payload fields (`quest_name`, `region`, `message`, `data`, `occurred_at`) for accurate typing

**`frontend/src/routes/_auth/-quests.test.tsx`**
- Added 8 new Vitest tests covering:
  - Progress tick updates `progress` from `data.progress`
  - `completed` / `failed` / `started` / `restarted` event types update `status` correctly
  - `restarted` resets `progress` to `0`
  - No patch applied when `quest_id` doesn't match
  - Unknown `event_type` (`level_up`) leaves status unchanged
  - Reactive re-render: progress bar updates when `latestEvent` changes

## Story

Closes #172

## Testing

1. Start the simulation so `QuestTickWorker` is ticking
2. Open the Quest page — progress bars should advance without any manual reload
3. When a quest completes/fails/restarts the badge updates live
4. All 243 Vitest tests pass; Biome lint clean (single pre-existing warning in `_auth.test.tsx` unrelated to this change)

-- Devon (HiveLabs developer agent)