### PR TITLE
feat: sort quest list — active first, completed last, others by campaign position

### DIFF
--- a/frontend/src/lib/questSort.test.ts
+++ b/frontend/src/lib/questSort.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import type { Quest } from '../schemas/quest';
+import { sortQuests } from './questSort';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeQuest(overrides: Partial<Quest> & { id: number; title: string }): Quest {
+  return {
+    status: 'pending',
+    danger_level: 1,
+    quest_type: 'campaign',
+    campaign_order: null,
+    attempts: 0,
+    progress: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('sortQuests', () => {
+  it('returns an empty array unchanged', () => {
+    expect(sortQuests([])).toEqual([]);
+  });
+
+  it('places active quests before pending quests', () => {
+    const quests = [
+      makeQuest({ id: 1, title: 'Pending', status: 'pending', campaign_order: 1 }),
+      makeQuest({ id: 2, title: 'Active', status: 'active', campaign_order: 2 }),
+    ];
+
+    const sorted = sortQuests(quests);
+    expect(sorted[0].status).toBe('active');
+    expect(sorted[1].status).toBe('pending');
+  });
+
+  it('places completed quests after all other quests', () => {
+    const quests = [
+      makeQuest({ id: 1, title: 'Completed', status: 'completed', campaign_order: 1 }),
+      makeQuest({ id: 2, title: 'Pending', status: 'pending', campaign_order: 2 }),
+      makeQuest({ id: 3, title: 'Active', status: 'active', campaign_order: 3 }),
+    ];
+
+    const sorted = sortQuests(quests);
+    expect(sorted[0].status).toBe('active');
+    expect(sorted[1].status).toBe('pending');
+    expect(sorted[2].status).toBe('completed');
+  });
+
+  it('sorts non-active, non-completed quests by campaign_order ascending', () => {
+    const quests = [
+      makeQuest({ id: 1, title: 'Third', status: 'pending', campaign_order: 3 }),
+      makeQuest({ id: 2, title: 'First', status: 'failed', campaign_order: 1 }),
+      makeQuest({ id: 3, title: 'Second', status: 'pending', campaign_order: 2 }),
+    ];
+
+    const sorted = sortQuests(quests);
+    expect(sorted.map((q) => q.campaign_order)).toEqual([1, 2, 3]);
+  });
+
+  it('places quests without campaign_order after those that have one (within same priority group)', () => {
+    const quests = [
+      makeQuest({ id: 1, title: 'No Order', status: 'pending', campaign_order: null }),
+      makeQuest({ id: 2, title: 'Has Order', status: 'pending', campaign_order: 1 }),
+    ];
+
+    const sorted = sortQuests(quests);
+    expect(sorted[0].title).toBe('Has Order');
+    expect(sorted[1].title).toBe('No Order');
+  });
+
+  it('handles the full priority order: active → others by campaign_order → completed', () => {
+    const quests = [
+      makeQuest({ id: 1, title: 'Completed Quest', status: 'completed', campaign_order: 1 }),
+      makeQuest({ id: 2, title: 'Active Quest', status: 'active', campaign_order: 2 }),
+      makeQuest({ id: 3, title: 'Pending Quest B', status: 'pending', campaign_order: 4 }),
+      makeQuest({ id: 4, title: 'Failed Quest', status: 'failed', campaign_order: 3 }),
+      makeQuest({ id: 5, title: 'Pending Quest A', status: 'pending', campaign_order: 2 }),
+    ];
+
+    const sorted = sortQuests(quests);
+
+    expect(sorted[0].title).toBe('Active Quest');
+    expect(sorted[1].title).toBe('Pending Quest A');
+    expect(sorted[2].title).toBe('Failed Quest');
+    expect(sorted[3].title).toBe('Pending Quest B');
+    expect(sorted[4].title).toBe('Completed Quest');
+  });
+
+  it('does not mutate the original array', () => {
+    const quests = [
+      makeQuest({ id: 1, title: 'Completed', status: 'completed', campaign_order: 1 }),
+      makeQuest({ id: 2, title: 'Active', status: 'active', campaign_order: 2 }),
+    ];
+    const original = [...quests];
+
+    sortQuests(quests);
+
+    expect(quests).toEqual(original);
+  });
+
+  it('handles multiple active quests, ordering them by campaign_order among themselves', () => {
+    const quests = [
+      makeQuest({ id: 1, title: 'Active B', status: 'active', campaign_order: 2 }),
+      makeQuest({ id: 2, title: 'Active A', status: 'active', campaign_order: 1 }),
+    ];
+
+    const sorted = sortQuests(quests);
+    expect(sorted[0].title).toBe('Active A');
+    expect(sorted[1].title).toBe('Active B');
+  });
+
+  it('handles multiple completed quests, ordering them by campaign_order among themselves', () => {
+    const quests = [
+      makeQuest({ id: 1, title: 'Completed B', status: 'completed', campaign_order: 2 }),
+      makeQuest({ id: 2, title: 'Completed A', status: 'completed', campaign_order: 1 }),
+    ];
+
+    const sorted = sortQuests(quests);
+    expect(sorted[0].title).toBe('Completed A');
+    expect(sorted[1].title).toBe('Completed B');
+  });
+
+  it('handles quests with mixed quest_types (campaign and random)', () => {
+    const quests = [
+      makeQuest({
+        id: 1,
+        title: 'Random Active',
+        status: 'active',
+        quest_type: 'random',
+        campaign_order: null,
+      }),
+      makeQuest({
+        id: 2,
+        title: 'Campaign Pending',
+        status: 'pending',
+        quest_type: 'campaign',
+        campaign_order: 1,
+      }),
+      makeQuest({
+        id: 3,
+        title: 'Random Pending',
+        status: 'pending',
+        quest_type: 'random',
+        campaign_order: null,
+      }),
+      makeQuest({
+        id: 4,
+        title: 'Campaign Completed',
+        status: 'completed',
+        quest_type: 'campaign',
+        campaign_order: 2,
+      }),
+    ];
+
+    const sorted = sortQuests(quests);
+
+    // Active first
+    expect(sorted[0].title).toBe('Random Active');
+    // Campaign quests with order before random quests without order
+    expect(sorted[1].title).toBe('Campaign Pending');
+    expect(sorted[2].title).toBe('Random Pending');
+    // Completed last
+    expect(sorted[3].title).toBe('Campaign Completed');
+  });
+});

--- a/frontend/src/lib/questSort.ts
+++ b/frontend/src/lib/questSort.ts
@@ -1,0 +1,41 @@
+import type { Quest } from '../schemas/quest';
+
+/**
+ * Return a numeric sort priority for a quest based on its status.
+ *
+ * 0 → active   (in-progress — most actionable, float to top)
+ * 1 → all other statuses (pending, failed) — secondary sort by campaign_order
+ * 2 → completed (least actionable — sink to bottom)
+ */
+function questSortPriority(quest: Quest): number {
+  if (quest.status === 'active') return 0;
+  if (quest.status === 'completed') return 2;
+  return 1;
+}
+
+/**
+ * Sort a quest list so that:
+ * 1. In-progress (active) quests appear first.
+ * 2. Completed quests appear last.
+ * 3. All other quests (pending, failed, etc.) are ordered by campaign_order
+ *    ascending. Quests without a campaign_order (e.g. random quests) are
+ *    placed after those that have one, preserving their relative order.
+ *
+ * The original array is not mutated; a new sorted array is returned.
+ */
+export function sortQuests(quests: Quest[]): Quest[] {
+  return [...quests].sort((a, b) => {
+    const pa = questSortPriority(a);
+    const pb = questSortPriority(b);
+
+    if (pa !== pb) return pa - pb;
+
+    // Within the same priority group, sort by campaign_order ascending.
+    // Quests without a campaign_order receive a large sentinel value so they
+    // sort after those that have one (preserving original relative order for
+    // ties via a stable sort).
+    const ca = a.campaign_order ?? Number.MAX_SAFE_INTEGER;
+    const cb = b.campaign_order ?? Number.MAX_SAFE_INTEGER;
+    return ca - cb;
+  });
+}

--- a/frontend/src/routes/_auth/quests.tsx
+++ b/frontend/src/routes/_auth/quests.tsx
@@ -20,6 +20,7 @@ import { QuestDetailModal } from '../../components/QuestDetailModal';
 import { useQuestEventsChannel } from '../../hooks/useQuestEventsChannel';
 import { useQuests } from '../../hooks/useQuests';
 import { api } from '../../lib/api';
+import { sortQuests } from '../../lib/questSort';
 import { type Quest, questSchema } from '../../schemas/quest';
 
 export const Route = createFileRoute('/_auth/quests')({
@@ -134,9 +135,10 @@ export function QuestsPage() {
     setSelectedQuest((prev) => (prev ? applyPatch(prev) : null));
   }, [latestEvent]);
 
-  // Client-side filtering by status.
+  // Client-side filtering by status, then sort: active first, completed last,
+  // others ordered by campaign_order.
   const filtered = useMemo(
-    () => liveQuests.filter((q) => !statusFilter || q.status === statusFilter),
+    () => sortQuests(liveQuests.filter((q) => !statusFilter || q.status === statusFilter)),
     [liveQuests, statusFilter],
   );
 


### PR DESCRIPTION
## Summary

- Extracts a pure `sortQuests` helper (`frontend/src/lib/questSort.ts`) for easy unit testing
- Sorts quests: **active** (in-progress) float to the top, **completed** sink to the bottom, all others (pending, failed) ordered by `campaign_order` ascending
- Applies the sort client-side in `QuestsPage` after the existing status filter

## Changes

- `frontend/src/lib/questSort.ts` — pure sort function with `questSortPriority` helper; returns a new array (no mutation)
- `frontend/src/lib/questSort.test.ts` — 10 Vitest unit tests covering all status combinations, campaign_order ordering, random quests without order, immutability, and multi-active/multi-completed ordering
- `frontend/src/routes/_auth/quests.tsx` — imports `sortQuests` and wraps the `filtered` `useMemo` output

## Story

Closes #173

## Testing

- `npm run test` — 253 tests pass (10 new in `questSort.test.ts`)
- `npm run lint` — no new warnings (pre-existing warning in `_auth.test.tsx` is unrelated)
- Sort logic: active → pending/failed by `campaign_order` → completed; random quests without `campaign_order` sort after campaign quests within the same priority group

-- Devon (HiveLabs developer agent)