### PR TITLE
fix: add sort-order integration tests to QuestsPage (#177)

### DIFF
--- a/frontend/src/routes/_auth/-quests.test.tsx
+++ b/frontend/src/routes/_auth/-quests.test.tsx
@@ -247,6 +247,86 @@ describe('QuestsPage', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Sort-order tests — verify sortQuests wiring in QuestsPage.
+  //
+  // The sort comparator uses the string 'active' (not 'in_progress') to identify
+  // in-progress quests — matching the backend enum value and the Zod schema enum.
+  // These tests confirm that wiring is correct end-to-end: the sortQuests helper
+  // IS applied to the rendered list, and the status string comparison works.
+  // ---------------------------------------------------------------------------
+  describe('quest list sort order', () => {
+    it('renders quests sorted on initial load: active first, others by campaign_order, completed last', () => {
+      // sampleQuests arrives in the order the API returns (alphabetical by title):
+      //   [Destroy the Ring / pending / order:1,
+      //    Scout the Shire  / active  / no order,
+      //    Defend Helms Deep / completed / order:2]
+      // Expected sort result: Scout (active) → Destroy (pending, order:1) → Defend (completed)
+      mockUseQuests.mockReturnValue({
+        quests: sampleQuests,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      render(<QuestsPage />, { wrapper });
+
+      const cards = screen.getAllByTestId('quest-card');
+      expect(cards).toHaveLength(3);
+      // Active quest must be first — status 'active' drives priority 0 in sortQuests.
+      expect(cards[0]).toHaveTextContent('Scout the Shire');
+      // Pending quest with lowest campaign_order comes next.
+      expect(cards[1]).toHaveTextContent('Destroy the Ring');
+      // Completed quest is always last.
+      expect(cards[2]).toHaveTextContent('Defend Helms Deep');
+    });
+
+    it('re-sorts after a started ActionCable event promotes a pending quest to active', () => {
+      // Start with all three quests pending, arriving alphabetically from the API.
+      const allPending = [
+        { ...sampleQuests[2], id: 3, status: 'pending', campaign_order: 2 }, // Defend Helms Deep
+        { ...sampleQuests[0], id: 1, status: 'pending', campaign_order: 1 }, // Destroy the Ring
+        { ...sampleQuests[1], id: 2, status: 'pending', campaign_order: null }, // Scout the Shire
+      ];
+      mockUseQuests.mockReturnValue({
+        quests: allPending,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: null,
+        connectionStatus: 'connected',
+      });
+
+      const { rerender } = render(<QuestsPage />, { wrapper });
+
+      // Before live update: all pending → sorted by campaign_order ascending.
+      // null campaign_order (Scout) sorts after numbered ones.
+      let cards = screen.getAllByTestId('quest-card');
+      expect(cards[0]).toHaveTextContent('Destroy the Ring'); // order: 1
+      expect(cards[1]).toHaveTextContent('Defend Helms Deep'); // order: 2
+      expect(cards[2]).toHaveTextContent('Scout the Shire'); // order: null → last
+
+      // Simulate a 'started' ActionCable event activating Scout the Shire (id: 2).
+      // Status is set to 'active' — the exact string checked by sortQuests.
+      mockUseQuestEventsChannel.mockReturnValue({
+        latestEvent: { event_type: 'started', quest_id: 2, data: {} },
+        connectionStatus: 'connected',
+      });
+
+      act(() => {
+        rerender(<QuestsPage />);
+      });
+
+      // After live update: Scout (now active) must float to position 0.
+      cards = screen.getAllByTestId('quest-card');
+      expect(cards[0]).toHaveTextContent('Scout the Shire'); // active → first
+      expect(cards[1]).toHaveTextContent('Destroy the Ring'); // pending, order: 1
+      expect(cards[2]).toHaveTextContent('Defend Helms Deep'); // pending, order: 2
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Live update tests — verify ActionCable event patches are applied correctly.
   // The broadcast payload shape from QuestEventBroadcaster is:
   //   { event_type, quest_id, quest_name, region, message, data, occurred_at }


### PR DESCRIPTION
## Summary

Fixes #177 — quest list appeared to render alphabetically instead of the intended status-group order.

**Root cause audit:** The `sortQuests` helper from PR #176 is correctly wired in `quests.tsx` (`filtered = sortQuests(liveQuests.filter(...))`) and the status comparator uses `'active'` — matching the backend enum value (`enum :status, { ..., active: "active", ... }`) and the Zod schema (`z.enum(['pending', 'active', 'completed', 'failed'])`). The sort logic itself is correct.

**Gap found:** `frontend/src/routes/_auth/-quests.test.tsx` had no assertions on the *order* of rendered quest cards. The test `renders quest cards from the mocked API response` only checked that three cards were present, not their sequence — so a wiring regression (or a future status-string mismatch) would go undetected.

## Changes

- **`frontend/src/routes/_auth/-quests.test.tsx`** — added a new `describe('quest list sort order')` block with two tests:
  1. **Initial load sort**: verifies that given `[pending/order:1, active/no-order, completed/order:2]` from the API, the rendered cards appear as `[active, pending, completed]` — active quest first, others by `campaign_order`, completed last.
  2. **Live-update re-sort**: verifies that after a `started` ActionCable event patches a pending quest to `status: 'active'`, the list re-sorts so that quest floats to position 0 (regression guard for the #172 ActionCable fix).

  Both tests use the `'active'` status string explicitly, documenting that this is the correct value (not `'in_progress'`) and locking in the comparator behaviour.

## Testing

- 2 new Vitest tests added; all 253 existing tests continue to pass (255 total)
- `npx biome check` passes with 0 errors (pre-existing `any` warning in auth test unrelated to this change)

## Story

Closes #177

-- Devon (HiveLabs developer agent)