### PR TITLE
feat: publish Playwright E2E report to GitHub Pages

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,12 @@ concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Required for GitHub Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   e2e:
     name: Playwright E2E
@@ -212,3 +218,31 @@ jobs:
       - name: Tear down
         if: always()
         run: docker compose -f docker-compose.e2e.yml down -v
+
+  deploy-report:
+    name: Publish Report to GitHub Pages
+    needs: e2e
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Download Playwright report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload to GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: playwright-report
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ Once the backend is running:
 
 ---
 
+## E2E Test Report
+
+The latest Playwright E2E test report from the `main` branch is automatically published to GitHub Pages after each successful CI run:
+
+- **Latest Report:** https://AshDevFr.github.io/experiment-RFHBX/
+
+---
+
 ## Built by AI Agents
 
 Mordor's Edge was entirely designed and built by the **HiveLabs** multi-agent team — a coordinated crew of specialised AI agents that plan, implement, review, and ship software collaboratively.


### PR DESCRIPTION
## Summary

Publishes the Playwright HTML test report to GitHub Pages after every successful E2E run on `main`, giving the team a permanent, browsable link to the latest test results.

### Changes

- **`.github/workflows/e2e.yml`** — Added a `deploy-report` job that:
  - Depends on the existing `e2e` job (only runs after tests complete)
  - Only triggers on pushes to `main` (not on PR runs)
  - Downloads the `playwright-report` artifact from the e2e job
  - Deploys it to GitHub Pages using `actions/deploy-pages@v4`
  - Added workflow-level `permissions` for `pages`, `id-token`, and `contents` required by the Pages deployment actions
- **`README.md`** — Added an \"E2E Test Report\" section with a link to the published report at `https://AshDevFr.github.io/experiment-RFHBX/`

### Prerequisites

GitHub Pages must be enabled on the repository:
1. Go to **Settings → Pages**
2. Set **Source** to **GitHub Actions**

No `gh-pages` branch is needed — the workflow uses the newer artifact-based deployment flow.

### Architecture Notes

- The deploy job uses the standard GitHub Pages action chain: `configure-pages` → `upload-pages-artifact` → `deploy-pages`
- The `github-pages` environment is referenced so deployments show up in the repo's Environments tab with the URL
- PR runs are explicitly excluded (`if: github.ref == 'refs/heads/main' && github.event_name == 'push'`) so only the latest `main` report is published
- The report includes test results, screenshots, and traces from the Playwright HTML reporter

Closes: N/A (user request for Playwright report publishing)

-- Sean (HiveLabs senior developer agent)